### PR TITLE
unytdtype improvements

### DIFF
--- a/unytdtype/tests/test_unytdtype.py
+++ b/unytdtype/tests/test_unytdtype.py
@@ -8,6 +8,10 @@ def test_dtype_creation():
     dtype = UnytDType("m")
     assert str(dtype) == "UnytDType('m')"
 
+    dtype2 = UnytDType(unyt.Unit('m'))
+    assert str(dtype2) == "UnytDType('m')"
+    assert dtype == dtype2
+
 
 def test_creation_from_zeros():
     dtype = UnytDType("m")

--- a/unytdtype/tests/test_unytdtype.py
+++ b/unytdtype/tests/test_unytdtype.py
@@ -13,6 +13,18 @@ def test_dtype_creation():
     assert dtype == dtype2
 
 
+def test_scalar_creation():
+    dtype = UnytDType("m")
+    unit = unyt.Unit("m")
+    unit_s = "m"
+
+    s_1 = UnytScalar(1, dtype)
+    s_2 = UnytScalar(1, unit)
+    s_3 = UnytScalar(1, unit_s)
+
+    assert s_1 == s_2 == s_3
+
+
 def test_creation_from_zeros():
     dtype = UnytDType("m")
     arr = np.zeros(3, dtype=dtype)

--- a/unytdtype/unytdtype/scalar.py
+++ b/unytdtype/unytdtype/scalar.py
@@ -5,16 +5,24 @@ from unyt import Unit
 
 class UnytScalar:
     def __init__(self, value, unit):
+        from . import UnytDType
         self.value = value
-        if isinstance(unit, str):
-            self.unit = Unit(unit)
-        elif isinstance(unit, Unit):
-            self.unit = unit
+        if isinstance(unit, (str, Unit)):
+            self.dtype = UnytDType(unit)
+        elif isinstance(unit, UnytDType):
+            self.dtype = unit
         else:
             raise RuntimeError
 
+    @property
+    def unit(self):
+        return self.dtype.unit
+
     def __repr__(self):
-        return f"{self.value} {self.unit}"
+        return f"{self.value} {self.dtype.unit}"
 
     def __rmul__(self, other):
-        return UnytScalar(self.value * other, self.unit)
+        return UnytScalar(self.value * other, self.dtype.unit)
+
+    def __eq__(self, other):
+        return self.value == other.value and self.dtype == other.dtype

--- a/unytdtype/unytdtype/src/casts.c
+++ b/unytdtype/unytdtype/src/casts.c
@@ -28,10 +28,22 @@ UnitConverter(PyObject *obj, PyObject **unit)
             return -1;
         }
     }
-    *unit = PyObject_GetAttr(unyt_mod, obj);
-    if (*unit == NULL) {
-        return 0;
+    PyTypeObject *unit_type =
+            (PyTypeObject *)PyObject_GetAttrString(unyt_mod, "Unit");
+    PyTypeObject *obj_type = Py_TYPE(obj);
+    if (obj_type == unit_type) {
+        Py_INCREF(obj);
+        *unit = obj;
     }
+    else {
+        // assume obj is a string unit name
+        *unit = PyObject_GetAttr(unyt_mod, obj);
+        if (*unit == NULL) {
+            Py_DECREF(unit_type);
+            return 0;
+        }
+    }
+    Py_DECREF(unit_type);
     return 1;
 }
 

--- a/unytdtype/unytdtype/src/dtype.c
+++ b/unytdtype/unytdtype/src/dtype.c
@@ -240,6 +240,12 @@ unytdtype_repr(UnytDTypeObject *self)
     return res;
 }
 
+static PyMemberDef UnytDType_members[] = {
+        {"unit", T_OBJECT_EX, offsetof(UnytDTypeObject, unit), READONLY,
+         "the unit"},
+        {NULL},
+};
+
 /*
  * This is the basic things that you need to create a Python Type/Class in C.
  * However, there is a slight difference here because we create a
@@ -254,6 +260,7 @@ PyArray_DTypeMeta UnytDType = {
                 .tp_dealloc = (destructor)unytdtype_dealloc,
                 .tp_repr = (reprfunc)unytdtype_repr,
                 .tp_str = (reprfunc)unytdtype_repr,
+                .tp_members = UnytDType_members,
         }},
         /* rest, filled in during DTypeMeta initialization */
 };

--- a/unytdtype/unytdtype/src/dtype.c
+++ b/unytdtype/unytdtype/src/dtype.c
@@ -43,7 +43,12 @@ get_unit(PyObject *scalar, UnytDTypeObject *descr)
         return descr->unit;
     }
 
-    PyObject *unit = PyObject_GetAttrString(scalar, "unit");
+    PyObject *dtype = PyObject_GetAttrString(scalar, "dtype");
+    if (dtype == NULL) {
+        return NULL;
+    }
+    PyObject *unit = PyObject_GetAttrString(dtype, "unit");
+    Py_DECREF(dtype);
     if (unit == NULL) {
         return NULL;
     }

--- a/unytdtype/unytdtype/src/dtype.h
+++ b/unytdtype/unytdtype/src/dtype.h
@@ -1,7 +1,10 @@
 #ifndef _NPY_DTYPE_H
 #define _NPY_DTYPE_H
 
+// clang-format off
 #include <Python.h>
+#include "structmember.h"
+// clang-format on
 
 #define PY_ARRAY_UNIQUE_SYMBOL unytdtype_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION


### PR DESCRIPTION
refactored a bit so `UnytScalar` doesn't hold any unit metadata, deferring to a `dtype` attribute instead. Makes it a little harder to accidentally have divergent units in the dtype and in the scalar.