### PR TITLE
BUG: (mpfdtype) The copyswap did not fix internal ref

### DIFF
--- a/mpfdtype/mpfdtype/src/casts.cpp
+++ b/mpfdtype/mpfdtype/src/casts.cpp
@@ -51,7 +51,7 @@ mpf_to_mpf_resolve_descriptors(
 
 
 static int
-mpf_to_mof_strided_loop(PyArrayMethod_Context *context,
+mpf_to_mpf_strided_loop(PyArrayMethod_Context *context,
         char *const data[], npy_intp const dimensions[],
         npy_intp const strides[], void *NPY_UNUSED(auxdata))
 {
@@ -395,9 +395,9 @@ init_casts_internal(void)
     PyType_Slot *mpf2mpf_slots = new PyType_Slot [4]{
         {NPY_METH_resolve_descriptors,
             (void *)&mpf_to_mpf_resolve_descriptors},
-        {NPY_METH_strided_loop, (void *)&mpf_to_mof_strided_loop},
+        {NPY_METH_strided_loop, (void *)&mpf_to_mpf_strided_loop},
         /* We don't actually support unaligned access... */
-        {NPY_METH_unaligned_strided_loop, (void *)&mpf_to_mof_strided_loop},
+        {NPY_METH_unaligned_strided_loop, (void *)&mpf_to_mpf_strided_loop},
         {0, nullptr}
     };
 

--- a/mpfdtype/mpfdtype/src/terrible_hacks.c
+++ b/mpfdtype/mpfdtype/src/terrible_hacks.c
@@ -27,7 +27,10 @@ copyswap_mpf(char *dst, char *src, int swap, PyArrayObject *ap)
     /* Note that it is probably better to only get the descr from `ap` */
     PyArray_Descr *descr = PyArray_DESCR(ap);
 
+    /* copy data and then fix significand (could also do same as cast...) */
     memcpy(dst, src, descr->elsize);
+    // TODO: To support unaligned data, only need to do this if it is aligned:
+    mpfr_custom_move((mpfr_ptr)dst, ((mpf_field *)dst)->significand);
 }
 
 

--- a/mpfdtype/mpfdtype/tests/test_array.py
+++ b/mpfdtype/mpfdtype/tests/test_array.py
@@ -1,0 +1,18 @@
+import pytest
+
+import sys
+import numpy as np
+import operator
+from numpy.testing import assert_array_equal
+
+from mpfdtype import MPFDType, MPFloat
+
+
+def test_advanced_indexing():
+    # As of writing the test, this relies on copyswap
+    arr = np.arange(100).astype(MPFDType(100))
+    orig = np.arange(100).astype(MPFDType(100))  # second one, not a copy
+
+    b = arr[[1, 2, 3, 4]]
+    b[...] = 5  # does not mutate arr (internal references not broken)
+    assert_array_equal(arr, orig)


### PR DESCRIPTION
Now its still buggy for unaligned access, but realistically that shouldn't happen much (and more is broken anyway, I believe).

Some other smaller cleanups, and a very small start for tests to check that the bug fix works ;).