### PR TITLE
Add round-trip casts between unicode and ASCIIDType

### DIFF
--- a/asciidtype/.flake8
+++ b/asciidtype/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 per-file-ignores = __init__.py:F401
+max-line-length = 160

--- a/asciidtype/asciidtype/src/casts.c
+++ b/asciidtype/asciidtype/src/casts.c
@@ -198,16 +198,11 @@ ascii_to_unicode(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         // copy ASCII input to first byte, fill rest with zeros
         for (int i = 0; i < copy_size; i++) {
-            *(out + i * 4) = *(in + i);
-            for (int j = 1; j < 4; j++) {
-                *(out + i * 4 + j) = '\0';
-            }
+            ((Py_UCS4 *)out)[i] = ((Py_UCS1 *)in)[i];
         }
         // fill all remaining UCS4 characters with zeros
         for (int i = copy_size; i < out_size; i++) {
-            for (int j = 0; j < 4; j++) {
-                *(out + i * 4 + j) = '\0';
-            }
+            ((Py_UCS4 *)out)[i] = (Py_UCS1)0;
         }
         in += in_stride;
         out += out_stride;

--- a/asciidtype/asciidtype/src/casts.c
+++ b/asciidtype/asciidtype/src/casts.c
@@ -269,9 +269,8 @@ get_casts(void)
     UnicodeToASCIICastSpec->name = u2a_name;
     UnicodeToASCIICastSpec->nin = 1;
     UnicodeToASCIICastSpec->nout = 1;
-    UnicodeToASCIICastSpec->casting = NPY_UNSAFE_CASTING,
-    UnicodeToASCIICastSpec->flags =
-            (NPY_METH_NO_FLOATINGPOINT_ERRORS | NPY_METH_REQUIRES_PYAPI);
+    UnicodeToASCIICastSpec->casting = NPY_UNSAFE_CASTING;
+    UnicodeToASCIICastSpec->flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
     UnicodeToASCIICastSpec->dtypes = u2a_dtypes;
     UnicodeToASCIICastSpec->slots = u2a_slots;
 
@@ -285,7 +284,7 @@ get_casts(void)
     ASCIIToUnicodeCastSpec->name = a2u_name;
     ASCIIToUnicodeCastSpec->nin = 1;
     ASCIIToUnicodeCastSpec->nout = 1;
-    ASCIIToUnicodeCastSpec->casting = NPY_UNSAFE_CASTING,
+    ASCIIToUnicodeCastSpec->casting = NPY_UNSAFE_CASTING;
     ASCIIToUnicodeCastSpec->flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
     ASCIIToUnicodeCastSpec->dtypes = a2u_dtypes;
     ASCIIToUnicodeCastSpec->slots = a2u_slots;

--- a/asciidtype/asciidtype/src/casts.c
+++ b/asciidtype/asciidtype/src/casts.c
@@ -73,9 +73,10 @@ ascii_to_ascii(PyArrayMethod_Context *context, char *const data[],
 }
 
 static int
-ascii_to_ascii_get_loop(PyArrayMethod_Context *context, int aligned,
+ascii_to_ascii_get_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                        int NPY_UNUSED(aligned),
                         int NPY_UNUSED(move_references),
-                        const npy_intp *strides,
+                        const npy_intp *NPY_UNUSED(strides),
                         PyArrayMethod_StridedLoop **out_loop,
                         NpyAuxData **NPY_UNUSED(out_transferdata),
                         NPY_ARRAYMETHOD_FLAGS *flags)

--- a/asciidtype/asciidtype/src/casts.c
+++ b/asciidtype/asciidtype/src/casts.c
@@ -109,9 +109,9 @@ unicode_to_ascii_resolve_descriptors(PyObject *NPY_UNUSED(self),
 static int
 ucs4_character_is_ascii(char *buffer)
 {
-    int first_char = buffer[0];
+    unsigned char first_char = buffer[0];
 
-    if (first_char < 0 || first_char > 127) {
+    if (first_char > 127) {
         return -1;
     }
 

--- a/asciidtype/asciidtype/src/casts.c
+++ b/asciidtype/asciidtype/src/casts.c
@@ -87,6 +87,190 @@ ascii_to_ascii_get_loop(PyArrayMethod_Context *NPY_UNUSED(context),
     return 0;
 }
 
+static NPY_CASTING
+unicode_to_ascii_resolve_descriptors(PyObject *NPY_UNUSED(self),
+                                     PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
+                                     PyArray_Descr *given_descrs[2],
+                                     PyArray_Descr *loop_descrs[2],
+                                     npy_intp *NPY_UNUSED(view_offset))
+{
+    Py_INCREF(given_descrs[0]);
+    loop_descrs[0] = given_descrs[0];
+    if (given_descrs[1] == NULL) {
+        Py_INCREF(given_descrs[0]);
+        loop_descrs[1] = given_descrs[0];
+    }
+    else {
+        Py_INCREF(given_descrs[1]);
+        loop_descrs[1] = given_descrs[1];
+    }
+
+    return NPY_SAME_KIND_CASTING;
+}
+
+static int
+ucs4_character_is_ascii(char *buffer)
+{
+    int first_char = buffer[0];
+
+    if (first_char < 0 || first_char > 127) {
+        return -1;
+    }
+
+    for (int i = 1; i < 4; i++) {
+        if (buffer[i] != 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int
+unicode_to_ascii(PyArrayMethod_Context *context, char *const data[],
+                 npy_intp const dimensions[], npy_intp const strides[],
+                 NpyAuxData *NPY_UNUSED(auxdata))
+{
+    PyArray_Descr **descrs = context->descriptors;
+    long in_size = (descrs[0]->elsize) / 4;
+    long out_size = ((ASCIIDTypeObject *)descrs[1])->size;
+    long copy_size;
+
+    if (out_size > in_size) {
+        copy_size = in_size;
+    }
+    else {
+        copy_size = out_size;
+    }
+
+    npy_intp N = dimensions[0];
+    char *in = data[0];
+    char *out = data[1];
+    npy_intp in_stride = strides[0];
+    npy_intp out_stride = strides[1];
+
+    while (N--) {
+        // copy input characters, checking that input UCS4
+        // characters are all ascii, raising an error otherwise
+        for (int i = 0; i < copy_size; i++) {
+            if (ucs4_character_is_ascii(in) == -1) {
+                PyGILState_STATE gstate;
+                gstate = PyGILState_Ensure();
+                PyErr_SetString(
+                        PyExc_TypeError,
+                        "Can only store ASCII text in a ASCIIDType array.");
+                PyGILState_Release(gstate);
+                return -1;
+            }
+            // UCS4 character is ascii, so copy first byte of character
+            // into output, ignoring the rest
+            *(out + i) = *(in + i * 4);
+        }
+        // write zeros to remaining ASCII characters (if any)
+        for (int i = copy_size; i < out_size; i++) {
+            *(out + i) = '\0';
+        }
+        in += in_stride;
+        out += out_stride;
+    }
+
+    return 0;
+}
+
+static int
+unicode_to_ascii_get_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                          int NPY_UNUSED(aligned),
+                          int NPY_UNUSED(move_references),
+                          const npy_intp *NPY_UNUSED(strides),
+                          PyArrayMethod_StridedLoop **out_loop,
+                          NpyAuxData **NPY_UNUSED(out_transferdata),
+                          NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    *out_loop = (PyArrayMethod_StridedLoop *)&unicode_to_ascii;
+
+    *flags = 0;
+    return 0;
+}
+
+static int
+ascii_to_unicode(PyArrayMethod_Context *context, char *const data[],
+                 npy_intp const dimensions[], npy_intp const strides[],
+                 NpyAuxData *NPY_UNUSED(auxdata))
+{
+    PyArray_Descr **descrs = context->descriptors;
+    long in_size = ((ASCIIDTypeObject *)descrs[0])->size;
+    long out_size = (descrs[1]->elsize) / 4;
+    long copy_size;
+
+    if (out_size > in_size) {
+        copy_size = in_size;
+    }
+    else {
+        copy_size = out_size;
+    }
+
+    npy_intp N = dimensions[0];
+    char *in = data[0];
+    char *out = data[1];
+    npy_intp in_stride = strides[0];
+    npy_intp out_stride = strides[1];
+
+    while (N--) {
+        // copy ASCII input to first byte, fill rest with zeros
+        for (int i = 0; i < copy_size; i++) {
+            *(out + i * 4) = *(in + i);
+            for (int j = 1; j < 4; j++) {
+                *(out + i * 4 + j) = '\0';
+            }
+        }
+        // fill all remaining UCS4 characters with zeros
+        for (int i = copy_size; i < out_size; i++) {
+            for (int j = 0; j < 4; j++) {
+                *(out + i * 4 + j) = '\0';
+            }
+        }
+        in += in_stride;
+        out += out_stride;
+    }
+    return 0;
+}
+
+static NPY_CASTING
+ascii_to_unicode_resolve_descriptors(PyObject *NPY_UNUSED(self),
+                                     PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
+                                     PyArray_Descr *given_descrs[2],
+                                     PyArray_Descr *loop_descrs[2],
+                                     npy_intp *NPY_UNUSED(view_offset))
+{
+    Py_INCREF(given_descrs[0]);
+    loop_descrs[0] = given_descrs[0];
+    if (given_descrs[1] == NULL) {
+        Py_INCREF(given_descrs[0]);
+        loop_descrs[1] = given_descrs[0];
+    }
+    else {
+        Py_INCREF(given_descrs[1]);
+        loop_descrs[1] = given_descrs[1];
+    }
+
+    return NPY_SAME_KIND_CASTING;
+}
+
+static int
+ascii_to_unicode_get_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                          int NPY_UNUSED(aligned),
+                          int NPY_UNUSED(move_references),
+                          const npy_intp *NPY_UNUSED(strides),
+                          PyArrayMethod_StridedLoop **out_loop,
+                          NpyAuxData **NPY_UNUSED(out_transferdata),
+                          NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    *out_loop = (PyArrayMethod_StridedLoop *)&ascii_to_unicode;
+
+    *flags = 0;
+    return 0;
+}
+
 static PyArray_DTypeMeta *a2a_dtypes[2] = {NULL, NULL};
 
 static PyType_Slot a2a_slots[] = {
@@ -103,3 +287,59 @@ PyArrayMethod_Spec ASCIIToASCIICastSpec = {
         .dtypes = a2a_dtypes,
         .slots = a2a_slots,
 };
+
+static PyType_Slot u2a_slots[] = {
+        {NPY_METH_resolve_descriptors, &unicode_to_ascii_resolve_descriptors},
+        {_NPY_METH_get_loop, &unicode_to_ascii_get_loop},
+        {0, NULL}};
+
+static char *u2a_name = "cast_Unicode_to_ASCIIDType";
+
+static PyType_Slot a2u_slots[] = {
+        {NPY_METH_resolve_descriptors, &ascii_to_unicode_resolve_descriptors},
+        {_NPY_METH_get_loop, &ascii_to_unicode_get_loop},
+        {0, NULL}};
+
+static char *a2u_name = "cast_ASCIIDType_to_Unicode";
+
+PyArrayMethod_Spec **
+get_casts(void)
+{
+    PyArray_DTypeMeta **u2a_dtypes = malloc(2 * sizeof(PyArray_DTypeMeta *));
+    u2a_dtypes[0] = &PyArray_UnicodeDType;
+    u2a_dtypes[1] = NULL;
+
+    PyArrayMethod_Spec *UnicodeToASCIICastSpec =
+            malloc(sizeof(PyArrayMethod_Spec));
+
+    UnicodeToASCIICastSpec->name = u2a_name;
+    UnicodeToASCIICastSpec->nin = 1;
+    UnicodeToASCIICastSpec->nout = 1;
+    UnicodeToASCIICastSpec->flags = NPY_METH_SUPPORTS_UNALIGNED;
+    UnicodeToASCIICastSpec->casting = NPY_SAME_KIND_CASTING;
+    UnicodeToASCIICastSpec->dtypes = u2a_dtypes;
+    UnicodeToASCIICastSpec->slots = u2a_slots;
+
+    PyArray_DTypeMeta **a2u_dtypes = malloc(2 * sizeof(PyArray_DTypeMeta *));
+    a2u_dtypes[0] = NULL;
+    a2u_dtypes[1] = &PyArray_UnicodeDType;
+
+    PyArrayMethod_Spec *ASCIIToUnicodeCastSpec =
+            malloc(sizeof(PyArrayMethod_Spec));
+
+    ASCIIToUnicodeCastSpec->name = a2u_name;
+    ASCIIToUnicodeCastSpec->nin = 1;
+    ASCIIToUnicodeCastSpec->nout = 1;
+    ASCIIToUnicodeCastSpec->flags = NPY_METH_SUPPORTS_UNALIGNED;
+    ASCIIToUnicodeCastSpec->casting = NPY_SAME_KIND_CASTING;
+    ASCIIToUnicodeCastSpec->dtypes = a2u_dtypes;
+    ASCIIToUnicodeCastSpec->slots = a2u_slots;
+
+    PyArrayMethod_Spec **casts = malloc(4 * sizeof(PyArrayMethod_Spec *));
+    casts[0] = &ASCIIToASCIICastSpec;
+    casts[1] = UnicodeToASCIICastSpec;
+    casts[2] = ASCIIToUnicodeCastSpec;
+    casts[3] = NULL;
+
+    return casts;
+}

--- a/asciidtype/asciidtype/src/casts.h
+++ b/asciidtype/asciidtype/src/casts.h
@@ -10,6 +10,7 @@
 #include "numpy/experimental_dtype_api.h"
 #include "numpy/ndarraytypes.h"
 
-extern PyArrayMethod_Spec ASCIIToASCIICastSpec;
+PyArrayMethod_Spec **
+get_casts(void);
 
 #endif /* _NPY_CASTS_H */

--- a/asciidtype/asciidtype/src/dtype.c
+++ b/asciidtype/asciidtype/src/dtype.c
@@ -45,20 +45,16 @@ get_value(PyObject *scalar)
  * Internal helper to create new instances
  */
 ASCIIDTypeObject *
-new_asciidtype_instance(PyObject *size)
+new_asciidtype_instance(long size)
 {
     ASCIIDTypeObject *new = (ASCIIDTypeObject *)PyArrayDescr_Type.tp_new(
             (PyTypeObject *)&ASCIIDType, NULL, NULL);
     if (new == NULL) {
         return NULL;
     }
-    long size_l = PyLong_AsLong(size);
-    if (size_l == -1 && PyErr_Occurred()) {
-        return NULL;
-    }
-    new->size = size_l;
-    new->base.elsize = size_l * sizeof(char);
-    new->base.alignment = size_l *_Alignof(char);
+    new->size = size;
+    new->base.elsize = size * sizeof(char);
+    new->base.alignment = size *_Alignof(char);
 
     return new;
 }
@@ -189,14 +185,11 @@ asciidtype_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwds)
 {
     static char *kwargs_strs[] = {"size", NULL};
 
-    PyObject *size = NULL;
+    long size = 0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:ASCIIDType", kwargs_strs,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|l:ASCIIDType", kwargs_strs,
                                      &size)) {
         return NULL;
-    }
-    if (size == NULL) {
-        size = PyLong_FromLong(0);
     }
 
     PyObject *ret = (PyObject *)new_asciidtype_instance(size);

--- a/asciidtype/asciidtype/src/dtype.c
+++ b/asciidtype/asciidtype/src/dtype.c
@@ -30,6 +30,12 @@ get_value(PyObject *scalar)
             return NULL;
         }
         ret_bytes = PyUnicode_AsASCIIString(value);
+        if (ret_bytes == NULL) {
+            PyErr_SetString(
+                    PyExc_TypeError,
+                    "Can only store ASCII text in a ASCIIDType array.");
+            return NULL;
+        }
         Py_DECREF(value);
     }
     return ret_bytes;

--- a/asciidtype/asciidtype/src/dtype.c
+++ b/asciidtype/asciidtype/src/dtype.c
@@ -245,7 +245,7 @@ PyArray_DTypeMeta ASCIIDType = {
 int
 init_ascii_dtype(void)
 {
-    static PyArrayMethod_Spec *casts[] = {&ASCIIToASCIICastSpec, NULL};
+    PyArrayMethod_Spec **casts = get_casts();
 
     PyArrayDTypeMeta_Spec ASCIIDType_DTypeSpec = {
             .flags = NPY_DT_PARAMETRIC,
@@ -272,6 +272,12 @@ init_ascii_dtype(void)
     }
 
     ASCIIDType.singleton = singleton;
+
+    free(ASCIIDType_DTypeSpec.casts[1]->dtypes);
+    free(ASCIIDType_DTypeSpec.casts[1]);
+    free(ASCIIDType_DTypeSpec.casts[2]->dtypes);
+    free(ASCIIDType_DTypeSpec.casts[2]);
+    free(ASCIIDType_DTypeSpec.casts);
 
     return 0;
 }

--- a/asciidtype/asciidtype/src/dtype.c
+++ b/asciidtype/asciidtype/src/dtype.c
@@ -16,6 +16,7 @@ get_value(PyObject *scalar)
             PyErr_SetString(
                     PyExc_TypeError,
                     "Can only store ASCII text in a ASCIIDType array.");
+            return NULL;
         }
     }
     else if (scalar_type != ASCIIScalar_Type) {

--- a/asciidtype/asciidtype/src/dtype.c
+++ b/asciidtype/asciidtype/src/dtype.c
@@ -200,7 +200,6 @@ asciidtype_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwds)
     }
 
     PyObject *ret = (PyObject *)new_asciidtype_instance(size);
-    Py_DECREF(size);
     return ret;
 }
 

--- a/asciidtype/asciidtype/src/dtype.h
+++ b/asciidtype/asciidtype/src/dtype.h
@@ -22,7 +22,7 @@ extern PyArray_DTypeMeta ASCIIDType;
 extern PyTypeObject *ASCIIScalar_Type;
 
 ASCIIDTypeObject *
-new_asciidtype_instance(PyObject *size);
+new_asciidtype_instance(long size);
 
 int
 init_ascii_dtype(void);

--- a/asciidtype/tests/test_asciidtype.py
+++ b/asciidtype/tests/test_asciidtype.py
@@ -78,8 +78,9 @@ def test_casting_to_asciidtype():
 def test_unicode_to_ascii_to_unicode():
     arr = np.array(["hello", "this", "is", "an", "array"])
     ascii_arr = arr.astype(ASCIIDType(5))
-    round_trip_arr = ascii_arr.astype("U5")
-    np.testing.assert_array_equal(arr, round_trip_arr)
+    for dtype in ["U5", np.unicode_, np.str_]:
+        round_trip_arr = ascii_arr.astype(dtype)
+        np.testing.assert_array_equal(arr, round_trip_arr)
 
 
 def test_creation_fails_with_non_ascii_characters():

--- a/asciidtype/tests/test_asciidtype.py
+++ b/asciidtype/tests/test_asciidtype.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -73,6 +75,71 @@ def test_casting_to_asciidtype():
         # assert repr(arr.astype(ASCIIDType())) == (
         #    "array(['', '', '', '', ''], dtype=ASCIIDType(0))"
         # )
+
+
+def test_casting_safety():
+    arr = np.array(["this", "is", "an", "array"])
+    assert repr(arr.astype(ASCIIDType(6), casting="safe")) == (
+        "array(['this', 'is', 'an', 'array'], dtype=ASCIIDType(6))"
+    )
+    assert repr(arr.astype(ASCIIDType(5), casting="safe")) == (
+        "array(['this', 'is', 'an', 'array'], dtype=ASCIIDType(5))"
+    )
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Cannot cast array data from dtype('<U5') to ASCIIDType(4) "
+            "according to the rule 'safe'"
+        ),
+    ):
+        assert repr(arr.astype(ASCIIDType(4), casting="safe")) == (
+            "array(['this', 'is', 'an', 'array'], dtype=ASCIIDType(5))"
+        )
+    assert repr(arr.astype(ASCIIDType(4), casting="unsafe")) == (
+        "array(['this', 'is', 'an', 'arra'], dtype=ASCIIDType(4))"
+    )
+
+    arr = np.array(["this", "is", "an", "array"], dtype=ASCIIDType(5))
+    assert repr(arr.astype(ASCIIDType(6), casting="safe")) == (
+        "array(['this', 'is', 'an', 'array'], dtype=ASCIIDType(6))"
+    )
+    assert repr(arr.astype(ASCIIDType(5), casting="safe")) == (
+        "array(['this', 'is', 'an', 'array'], dtype=ASCIIDType(5))"
+    )
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Cannot cast array data from ASCIIDType(5) to ASCIIDType(4) "
+            "according to the rule 'safe'"
+        ),
+    ):
+        assert repr(arr.astype(ASCIIDType(4), casting="safe")) == (
+            "array(['this', 'is', 'an', 'array'], dtype=ASCIIDType(5))"
+        )
+    assert repr(arr.astype(ASCIIDType(4), casting="unsafe")) == (
+        "array(['this', 'is', 'an', 'arra'], dtype=ASCIIDType(4))"
+    )
+
+    arr = np.array(["this", "is", "an", "array"], dtype=ASCIIDType(5))
+    assert repr(arr.astype("U6", casting="safe")) == (
+        "array(['this', 'is', 'an', 'array'], dtype='<U6')"
+    )
+    assert repr(arr.astype("U5", casting="safe")) == (
+        "array(['this', 'is', 'an', 'array'], dtype='<U5')"
+    )
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Cannot cast array data from ASCIIDType(5) to dtype('<U4') "
+            "according to the rule 'safe'"
+        ),
+    ):
+        assert repr(arr.astype("U4", casting="safe")) == (
+            "array(['this', 'is', 'an', 'array'], dtype=ASCIIDType(5))"
+        )
+    assert repr(arr.astype("U4", casting="unsafe")) == (
+        "array(['this', 'is', 'an', 'arra'], dtype='<U4')"
+    )
 
 
 def test_unicode_to_ascii_to_unicode():


### PR DESCRIPTION
Since Numpy stores unicode data internally as UCS4, I can do these casts relatively straightforwardly without worrying about encoding details. 

For unicode to ASCII, I check character by character (e.g. 4 bytes at a time) if the UCS4 character is valid ASCII, if it is I assign the first byte of the character to the corresponding byte of the output array. If we find an invalid ASCII character, we re-acquire the GIL, set a `TypeError`, release the GIL, and return.

For ASCII to unicode, no error checking is needed, so we just set the ASCII character to the first byte of the corresponding character in the output array, and set the rest of the bytes in the character to zero.

This also includes some other misc fixes I noticed along the way around error checking and handling reference counts.

Finally, mostly as a note to myself to check this tomorrow, I noticed that if I do a round-trip from unicode to ascii back to unicode, but I phrase it like this:

```
arr = np.array(["hello", "this", "is", "an", "array"])
ascii_arr = arr.astype(ASCIIDType(5))
round_trip_arr = ascii_arr.astype(np.unicode_)
```

the resulting array will still have `ASCIIDType(5)` as the dtype. If I specify the output dtype as a string (`ascii_arr.astype('U5')` as I've done in the round-trip test I added in this PR), it works fine. I need to look into the implementation of `astype` to understand why that's happening, I suspect it's a numpy bug.