### PR TITLE
acquire GIL for error condition in unicode to ascii cast

### DIFF
--- a/asciidtype/asciidtype/src/casts.c
+++ b/asciidtype/asciidtype/src/casts.c
@@ -135,9 +135,12 @@ unicode_to_ascii(PyArrayMethod_Context *context, char *const data[],
         for (int i = 0; i < copy_size; i++) {
             Py_UCS4 c = ((Py_UCS4 *)in)[i];
             if (c > 127) {
+                PyGILState_STATE gstate;
+                gstate = PyGILState_Ensure();
                 PyErr_SetString(
                         PyExc_TypeError,
                         "Can only store ASCII text in a ASCIIDType array.");
+                PyGILState_Release(gstate);
                 return -1;
             }
             // UCS4 character is ascii, so casting to Py_UCS1 does not truncate


### PR DESCRIPTION
I neglected to add the incantation to re-acquire the GIL in the error condition when I dropped the `NPY_METH_REQUIRES_PYAPI` flag for this cast. This adds it, which should hopefully prevent a crash that the current tests happen to not trigger.