### PR TITLE
update get_value now that ASCIIScalar is a str subclass

### DIFF
--- a/asciidtype/asciidtype/src/dtype.c
+++ b/asciidtype/asciidtype/src/dtype.c
@@ -25,18 +25,13 @@ get_value(PyObject *scalar)
         return NULL;
     }
     else {
-        PyObject *value = PyObject_GetAttrString(scalar, "value");
-        if (value == NULL) {
-            return NULL;
-        }
-        ret_bytes = PyUnicode_AsASCIIString(value);
+        ret_bytes = PyUnicode_AsASCIIString(scalar);
         if (ret_bytes == NULL) {
             PyErr_SetString(
                     PyExc_TypeError,
                     "Can only store ASCII text in a ASCIIDType array.");
             return NULL;
         }
-        Py_DECREF(value);
     }
     return ret_bytes;
 }

--- a/asciidtype/tests/test_asciidtype.py
+++ b/asciidtype/tests/test_asciidtype.py
@@ -213,3 +213,11 @@ def test_equality(input1, input2, expected):
     expected = np.array(expected, dtype=np.bool_)
     np.testing.assert_array_equal(input1 == input2, expected)
     np.testing.assert_array_equal(input2 == input1, expected)
+
+
+def test_insert_scalar_directly():
+    dtype = ASCIIDType(5)
+    arr = np.array(["some", "array"], dtype=dtype)
+    val = arr[0]
+    arr[1] = val
+    np.testing.assert_array_equal(arr, np.array(["some", "some"], dtype=dtype))


### PR DESCRIPTION
The test I added currently fails with an `AttributeError` because `value` is no longer an attribute of `ASCIIScalar`.