### PR TITLE
fixes for StringDType

### DIFF
--- a/asciidtype/asciidtype/scalar.py
+++ b/asciidtype/asciidtype/scalar.py
@@ -6,3 +6,11 @@ class ASCIIScalar(str):
         instance = super().__new__(cls, value)
         instance.dtype = dtype
         return instance
+
+    def partition(self, sep):
+        ret = super().partition(sep)
+        return (str(ret[0]), str(ret[1]), str(ret[2]))
+
+    def rpartition(self, sep):
+        ret = super().rpartition(sep)
+        return (str(ret[0]), str(ret[1]), str(ret[2]))

--- a/stringdtype/README.md
+++ b/stringdtype/README.md
@@ -1,6 +1,6 @@
-# A dtype that stores ASCII data
+# A dtype that stores pointers to strings
 
-This is a simple proof-of-concept dtype using the (as of late 2022) experimental
+This is a simple proof-of-concept dtype using the (as of early 2023) experimental
 [new dtype
 implementation](https://numpy.org/neps/nep-0041-improved-dtype-support.html) in
 NumPy.

--- a/stringdtype/stringdtype/scalar.py
+++ b/stringdtype/stringdtype/scalar.py
@@ -1,12 +1,16 @@
 """A scalar type needed by the dtype machinery."""
 
 
-class StringScalar:
-    def __init__(self, value):
-        self.value = value
+class StringScalar(str):
+    def __new__(cls, value, dtype):
+        instance = super().__new__(cls, value)
+        instance.dtype = dtype
+        return instance
 
-    def __str__(self):
-        return str(self.value)
+    def partition(self, sep):
+        ret = super().partition(sep)
+        return (str(ret[0]), str(ret[1]), str(ret[2]))
 
-    def __repr__(self):
-        return repr(self.value)
+    def rpartition(self, sep):
+        ret = super().rpartition(sep)
+        return (str(ret[0]), str(ret[1]), str(ret[2]))


### PR DESCRIPTION
This brings over some functionality from `asciidtype`. I also include some `asciidtype` changes here to keep `stringdtype` and `asciidtype` more uniform.

* Makes `StringScalar` a `str` subclass. This makes it possible to use the functions in `np.char` to manipulate `StringDType` data
    * Adds `partition` and `rpartition` wrappers to make sure the result of those functions has uniform types.
* Adds a missing incref to `common_instance`. Also simplifies it a bit since `StringDType` isn't parametric.
* Can create a `StringDType` with an optional `size` argument, which gets ignored. This makes the API more uniform with numpy's other string dtypes. In particular, this way of creating a string dtype is now used in `np.char`, so this also allows `StringDType` to work with functions in `np.char`. Currently we just ignore the `size` but in principle we could use it as a size hint? I'm not sure if that's actually useful.