### PR TITLE
Add ufunc promoter for equal

### DIFF
--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -34,13 +34,23 @@ common_instance(StringDTypeObject *dtype1, StringDTypeObject *dtype2)
     return dtype1;
 }
 
+/*
+ *  Used to determine the correct "common" dtype for promotion.
+ *  cls is always StringDType, other is an arbitrary other DType
+ */
 static PyArray_DTypeMeta *
 common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
 {
-    // for now always raise an error here until we can figure out
-    // how to deal with strings here
-    PyErr_SetString(PyExc_RuntimeError, "common_dtype called in StringDType");
-    return NULL;
+    if (other->type_num == NPY_UNICODE) {
+        /*
+         *  We have a cast from unicode, so allow unicode to promote
+         *  to StringDType
+         */
+        Py_INCREF(cls);
+        return cls;
+    }
+    Py_INCREF(Py_NotImplemented);
+    return (PyArray_DTypeMeta *)Py_NotImplemented;
 }
 
 // For a given python object, this function returns a borrowed reference

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -96,3 +96,11 @@ def test_insert_scalar(string_list):
     arr = np.array(string_list, dtype=dtype)
     arr[1] = StringScalar("what", dtype=dtype)
     assert repr(arr) == repr(np.array(["abc", "what", "ghi"], dtype=dtype))
+
+
+def test_equality_promotion(string_list):
+    sarr = np.array(string_list, dtype=StringDType())
+    uarr = np.array(string_list, dtype=np.str_)
+
+    np.testing.assert_array_equal(sarr, uarr)
+    np.testing.assert_array_equal(uarr, sarr)


### PR DESCRIPTION
This adds a promoter implementation for the equal ufunc. This makes it so that if you pass a fixed-width unicode string dtype and a `StringDType` array to `np.equal`, numpy will automatically cast the `Unicode` to `StringDType`.

@seberg is there a way to do this without adding the promoter twice? If not, would it make sense for `PyUFunc_AddPromoter` to add two promoters, one with the input arguments switched? I tried only doing it once and the promoter only kicked in for when `StringDType` was the first parameter, so I think the order does matter currently.

`default_ufunc_promoter` is copy/pasted from numpy. Should I be doing something a little more precise?