### PR TITLE
update to new DType API version

### DIFF
--- a/asciidtype/asciidtype/src/asciidtype_main.c
+++ b/asciidtype/asciidtype/src/asciidtype_main.c
@@ -21,7 +21,7 @@ PyInit__asciidtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(5) < 0) {
+    if (import_experimental_dtype_api(6) < 0) {
         return NULL;
     }
 

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -21,7 +21,7 @@ PyInit__metadatadtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(5) < 0) {
+    if (import_experimental_dtype_api(6) < 0) {
         return NULL;
     }
 

--- a/mpfdtype/mpfdtype/src/mpfdtype_main.c
+++ b/mpfdtype/mpfdtype/src/mpfdtype_main.c
@@ -9,21 +9,20 @@
 #include "umath.h"
 #include "terrible_hacks.h"
 
-
 static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    .m_name = "mpfdtype_main",
-    .m_size = -1,
+        PyModuleDef_HEAD_INIT,
+        .m_name = "mpfdtype_main",
+        .m_size = -1,
 };
 
-
 /* Module initialization function */
-PyMODINIT_FUNC PyInit__mpfdtype_main(void)
+PyMODINIT_FUNC
+PyInit__mpfdtype_main(void)
 {
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(5) < 0) {
+    if (import_experimental_dtype_api(6) < 0) {
         return NULL;
     }
 
@@ -36,8 +35,7 @@ PyMODINIT_FUNC PyInit__mpfdtype_main(void)
         goto error;
     }
 
-    if (PyModule_AddObject(m,
-            "MPFloat", (PyObject *)&MPFloat_Type) < 0) {
+    if (PyModule_AddObject(m, "MPFloat", (PyObject *)&MPFloat_Type) < 0) {
         goto error;
     }
 
@@ -45,8 +43,7 @@ PyMODINIT_FUNC PyInit__mpfdtype_main(void)
         goto error;
     }
 
-    if (PyModule_AddObject(m,
-            "MPFDType", (PyObject *)&MPFDType) < 0) {
+    if (PyModule_AddObject(m, "MPFDType", (PyObject *)&MPFDType) < 0) {
         goto error;
     }
 
@@ -60,7 +57,7 @@ PyMODINIT_FUNC PyInit__mpfdtype_main(void)
 
     return m;
 
-  error:
+error:
     Py_DECREF(m);
     return NULL;
 }

--- a/quaddtype/quaddtype/src/quaddtype_main.c
+++ b/quaddtype/quaddtype/src/quaddtype_main.c
@@ -23,7 +23,7 @@ PyInit__quaddtype_main(void)
         return NULL;
 
     // Fail to init if the experimental DType API version 5 isn't supported
-    if (import_experimental_dtype_api(5) < 0) {
+    if (import_experimental_dtype_api(6) < 0) {
         PyErr_SetString(PyExc_ImportError,
                         "Error encountered importing the experimental dtype API.");
         return NULL;

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -21,7 +21,7 @@ PyInit__main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(5) < 0) {
+    if (import_experimental_dtype_api(6) < 0) {
         return NULL;
     }
 

--- a/unytdtype/unytdtype/src/unytdtype_main.c
+++ b/unytdtype/unytdtype/src/unytdtype_main.c
@@ -21,7 +21,7 @@ PyInit__unytdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(5) < 0) {
+    if (import_experimental_dtype_api(6) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
https://github.com/numpy/numpy/pull/20970 bumped the DType API version, so let's bump the API version here as well to fix the tests. In principle some of these dtypes could use the new API slot, but going to punt on that for now unless there's new test breakage.