### PR TITLE
store string data in a struct along with length

### DIFF
--- a/stringdtype/meson.build
+++ b/stringdtype/meson.build
@@ -26,6 +26,8 @@ srcs = [
   'stringdtype/src/casts.h',
   'stringdtype/src/dtype.c',
   'stringdtype/src/main.c',
+  'stringdtype/src/static_string.c',
+  'stringdtype/src/static_string.h',
   'stringdtype/src/umath.c',
   'stringdtype/src/umath.h',
 ]

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -1,6 +1,7 @@
 #include "dtype.h"
 
 #include "casts.h"
+#include "static_string.h"
 
 PyTypeObject *StringScalar_Type = NULL;
 
@@ -15,8 +16,8 @@ new_stringdtype_instance(void)
     if (new == NULL) {
         return NULL;
     }
-    new->base.elsize = sizeof(char *);
-    new->base.alignment = _Alignof(char *);
+    new->base.elsize = sizeof(ss *);
+    new->base.alignment = _Alignof(ss *);
 
     return new;
 }
@@ -113,8 +114,7 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
         return -1;
     }
 
-    *dataptr = malloc(sizeof(char) * length + 1);
-    strncpy(*dataptr, val, length + 1);
+    *dataptr = (char *)ssnewlen(val, length);
     Py_DECREF(val_obj);
     return 0;
 }
@@ -122,7 +122,7 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
 static PyObject *
 stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
 {
-    PyObject *val_obj = PyUnicode_FromString(*dataptr);
+    PyObject *val_obj = PyUnicode_FromString(((ss *)*dataptr)->buf);
 
     if (val_obj == NULL) {
         return NULL;

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -114,7 +114,12 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
         return -1;
     }
 
-    *dataptr = (char *)ssnewlen(val, length);
+    ss *str_val = ssnewlen(val, length);
+    if (str_val == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "ssnewlen failed");
+        return -1;
+    }
+    *dataptr = (char *)str_val;
     Py_DECREF(val_obj);
     return 0;
 }

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -18,6 +18,7 @@ new_stringdtype_instance(void)
     }
     new->base.elsize = sizeof(ss *);
     new->base.alignment = _Alignof(ss *);
+    new->base.flags |= NPY_NEEDS_INIT;
 
     return new;
 }
@@ -118,6 +119,12 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
     if (str_val == NULL) {
         PyErr_SetString(PyExc_MemoryError, "ssnewlen failed");
         return -1;
+    }
+    // the dtype instance has the NPY_NEEDS_INIT flag set,
+    // so if *dataptr is NULL, that means we're initializing
+    // the array and don't need to free an existing string
+    if (*dataptr != NULL) {
+        free((ss *)*dataptr);
     }
     *dataptr = (char *)str_val;
     Py_DECREF(val_obj);

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -1,0 +1,41 @@
+#include "static_string.h"
+
+// allocates a new ss string of length len, filling with the contents of init
+ss *
+ssnewlen(const char *init, size_t len)
+{
+    // one extra byte for null terminator
+    ss *ret = (ss *)malloc(sizeof(ss) + sizeof(char) * (len + 1));
+
+    if (ret == NULL) {
+        return NULL;
+    }
+
+    ret->len = len;
+
+    if (len > 0) {
+        memcpy(ret->buf, init, len);
+    }
+
+    ret->buf[len] = '\0';
+
+    return ret;
+}
+
+// returns a new heap-allocated copy of input string *s*
+ss *
+ssdup(const ss *s)
+{
+    return ssnewlen(s->buf, s->len);
+}
+
+// returns a new, empty string of length len
+// does not do any initialization, the caller must
+// initialize and null-terminate the string
+ss *
+ssnewempty(size_t len)
+{
+    ss *ret = (ss *)malloc(sizeof(ss) + sizeof(char) * (len + 1));
+    ret->len = len;
+    return ret;
+}

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -1,0 +1,26 @@
+#ifndef _NPY_STATIC_STRING_H
+#define _NPY_STATIC_STRING_H
+
+#include "stdlib.h"
+#include "string.h"
+
+typedef struct ss {
+    size_t len;
+    char buf[];
+} ss;
+
+// allocates a new ss string of length len, filling with the contents of init
+ss *
+ssnewlen(const char *init, size_t len);
+
+// returns a new heap-allocated copy of input string *s*
+ss *
+ssdup(const ss *s);
+
+// returns a new, empty string of length len
+// does not do any initialization, the caller must
+// initialize and null-terminate the string
+ss *
+ssnewempty(size_t len);
+
+#endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -9,6 +9,7 @@
 #include "numpy/ufuncobject.h"
 
 #include "dtype.h"
+#include "static_string.h"
 #include "string.h"
 #include "umath.h"
 
@@ -19,8 +20,8 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
                           NpyAuxData *NPY_UNUSED(auxdata))
 {
     npy_intp N = dimensions[0];
-    char **in1 = (char **)data[0];
-    char **in2 = (char **)data[1];
+    ss **in1 = (ss **)data[0];
+    ss **in2 = (ss **)data[1];
     npy_bool *out = (npy_bool *)data[2];
     // strides are in bytes but pointer offsets are in pointer widths, so
     // divide by the element size (one pointer width) to get the pointer offset
@@ -29,7 +30,18 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[2];
 
     while (N--) {
-        if (strcmp(*in1, *in2) == 0) {
+        size_t len1 = (*in1)->len;
+        size_t len2 = (*in2)->len;
+        size_t maxlen;
+
+        if (len1 > len2) {
+            maxlen = len1;
+        }
+        else {
+            maxlen = len2;
+        }
+
+        if (strncmp((*in1)->buf, (*in2)->buf, maxlen) == 0) {
             *out = (npy_bool)1;
         }
         else {

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -30,18 +30,10 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[2];
 
     while (N--) {
-        size_t len1 = (*in1)->len;
-        size_t len2 = (*in2)->len;
-        size_t maxlen;
+        ss *s1 = *in1;
+        ss *s2 = *in2;
 
-        if (len1 > len2) {
-            maxlen = len1;
-        }
-        else {
-            maxlen = len2;
-        }
-
-        if (strncmp((*in1)->buf, (*in2)->buf, maxlen) == 0) {
+        if (s1->len == s2->len && strncmp(s1->buf, s2->buf, s1->len) == 0) {
             *out = (npy_bool)1;
         }
         else {


### PR DESCRIPTION
This makes the dtype store the string data in a struct:

```C
typedef struct ss {
    size_t len;
    char buf[];
} ss;
```

So far this is just a refactoring but the hope is that storing the length will avoid O(N) `strlen` calls and make it easier to write code that doesn't accidentally introduce buffer overflows.

Bikeshedding on the naming and the API are very welcome.