### PR TITLE
refactor ufunc setup and add isnan loop

### DIFF
--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -104,3 +104,10 @@ def test_equality_promotion(string_list):
 
     np.testing.assert_array_equal(sarr, uarr)
     np.testing.assert_array_equal(uarr, sarr)
+
+
+def test_isnan(string_list):
+    sarr = np.array(string_list, dtype=StringDType())
+    np.testing.assert_array_equal(
+        np.isnan(sarr), np.zeros_like(sarr, dtype=np.bool_)
+    )


### PR DESCRIPTION
This refactors the ufunc setup to be more generic. It also adds support for `isnan`, which is needed by pandas' data ingestion code.

In the future we might want to think about `NA` support, but for now I've just made `isnan` unconditionally return `False`.

~~The tests will likely fail until the numpy nightly wheel is rebuilt using a version including `https://github.com/numpy/numpy/pull/23094.~~

Never mind, seems the nightly wheel was already rebuilt.