### PR TITLE
add asan to stringdtype build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,14 @@ jobs:
       - name: Install stringdtype
         working-directory: stringdtype
         run: |
-          python -m build --no-isolation --wheel -Cbuilddir=build
+          if [ -d "build/" ]
+          then
+              rm -r build
+          fi
+          meson setup build -Db_sanitize=address,undefined
+          python -m build --no-isolation --wheel -Cbuilddir=build --config-setting='compile-args=-v'
           find ./dist/*.whl | xargs python -m pip install
       - name: Run stringdtype tests
         working-directory: stringdtype
         run: |
-          pytest -vvv --color=yes
+          ASAN_OPTIONS=detect_leaks=false LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/11/libasan.so pytest -s -vvv --color=yes

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -251,7 +251,7 @@ init_string_dtype(void)
     free(StringDType_DTypeSpec.casts[1]->dtypes);
     free(StringDType_DTypeSpec.casts[1]);
     free(StringDType_DTypeSpec.casts[2]->dtypes);
-    free(StringDType_DTypeSpec.casts[2]);
+    free(StringDType_DTypeSpec.casts[4]);
     free(StringDType_DTypeSpec.casts);
 
     return 0;

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -251,7 +251,7 @@ init_string_dtype(void)
     free(StringDType_DTypeSpec.casts[1]->dtypes);
     free(StringDType_DTypeSpec.casts[1]);
     free(StringDType_DTypeSpec.casts[2]->dtypes);
-    free(StringDType_DTypeSpec.casts[4]);
+    free(StringDType_DTypeSpec.casts[2]);
     free(StringDType_DTypeSpec.casts);
 
     return 0;


### PR DESCRIPTION
This builds stringdtype with asan support. I also pass `-s` to pytest so pytest doesn't capture the output from asan when a test fails.