### PR TITLE
uncomment zero-length test in ASCIIDType

### DIFF
--- a/asciidtype/tests/test_asciidtype.py
+++ b/asciidtype/tests/test_asciidtype.py
@@ -55,10 +55,10 @@ def test_creation_truncation():
     )
     assert arr.tobytes() == b"htiaa"
 
-    # dtype = ASCIIDType()
-    # arr = np.array(["hello", "this", "is", "an", "array"], dtype=dtype)
-    # assert repr(arr) == ("array(['', '', '', '', ''], dtype=ASCIIDType(0))")
-    # assert arr.tobytes() == b""
+    dtype = ASCIIDType()
+    arr = np.array(["hello", "this", "is", "an", "array"], dtype=dtype)
+    assert repr(arr) == ("array(['', '', '', '', ''], dtype=ASCIIDType(0))")
+    assert arr.tobytes() == b""
 
 
 def test_casting_to_asciidtype():


### PR DESCRIPTION
This test was commented out in #11, waiting on https://github.com/numpy/numpy/pull/22763 to be merged. Uncommenting now that the test should work with the Numpy nightly wheel.