### PR TITLE
include parens in StringDType repr

### DIFF
--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -30,7 +30,8 @@ new_stringdtype_instance(void)
  * we can safely always return the first one.
  */
 static StringDTypeObject *
-common_instance(StringDTypeObject *dtype1, StringDTypeObject *dtype2)
+common_instance(StringDTypeObject *dtype1,
+                StringDTypeObject *NPY_UNUSED(dtype2))
 {
     Py_INCREF(dtype1);
     return dtype1;
@@ -102,7 +103,8 @@ get_value(PyObject *scalar)
 // Take a python object `obj` and insert it into the array of dtype `descr` at
 // the position given by dataptr.
 static int
-stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
+stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
+                    char **dataptr)
 {
     PyObject *val_obj = get_value(obj);
     if (val_obj == NULL) {
@@ -193,9 +195,9 @@ stringdtype_dealloc(StringDTypeObject *self)
 }
 
 static PyObject *
-stringdtype_repr(StringDTypeObject *self)
+stringdtype_repr(StringDTypeObject *NPY_UNUSED(self))
 {
-    return PyUnicode_FromString("StringDType");
+    return PyUnicode_FromString("StringDType()");
 }
 
 /*

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -14,7 +14,7 @@ def test_scalar_creation():
 
 
 def test_dtype_creation():
-    assert str(StringDType()) == "StringDType"
+    assert str(StringDType()) == "StringDType()"
 
 
 def test_dtype_equality():
@@ -34,7 +34,7 @@ def test_dtype_equality():
 )
 def test_array_creation_utf8(data):
     arr = np.array(data, dtype=StringDType())
-    assert repr(arr) == f"array({str(data)}, dtype=StringDType)"
+    assert repr(arr) == f"array({str(data)}, dtype=StringDType())"
 
 
 def test_array_creation_scalars(string_list):


### PR DESCRIPTION
Passing `StringDType` directly as a `dtype` argument won't work until https://github.com/numpy/numpy/issues/22756 is fixed. Let's make the repr be something that works now.