### PR TITLE
adapt to change in resolve_descriptors_function signature

### DIFF
--- a/asciidtype/asciidtype/src/asciidtype_main.c
+++ b/asciidtype/asciidtype/src/asciidtype_main.c
@@ -21,7 +21,8 @@ PyInit__asciidtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(6) < 0) {
+
+    if (import_experimental_dtype_api(7) < 0) {
         return NULL;
     }
 

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -21,7 +21,7 @@ PyInit__metadatadtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(6) < 0) {
+    if (import_experimental_dtype_api(7) < 0) {
         return NULL;
     }
 

--- a/mpfdtype/mpfdtype/src/mpfdtype_main.c
+++ b/mpfdtype/mpfdtype/src/mpfdtype_main.c
@@ -22,7 +22,7 @@ PyInit__mpfdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(6) < 0) {
+    if (import_experimental_dtype_api(7) < 0) {
         return NULL;
     }
 

--- a/quaddtype/quaddtype/src/quaddtype_main.c
+++ b/quaddtype/quaddtype/src/quaddtype_main.c
@@ -23,7 +23,7 @@ PyInit__quaddtype_main(void)
         return NULL;
 
     // Fail to init if the experimental DType API version 5 isn't supported
-    if (import_experimental_dtype_api(6) < 0) {
+    if (import_experimental_dtype_api(7) < 0) {
         PyErr_SetString(PyExc_ImportError,
                         "Error encountered importing the experimental dtype API.");
         return NULL;

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -90,7 +90,7 @@ PyInit__main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(6) < 0) {
+    if (import_experimental_dtype_api(7) < 0) {
         return NULL;
     }
 

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -48,11 +48,10 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
 }
 
 static NPY_CASTING
-string_equal_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                 PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-                                 PyArray_Descr *given_descrs[],
-                                 PyArray_Descr *loop_descrs[],
-                                 npy_intp *NPY_UNUSED(view_offset))
+string_equal_resolve_descriptors(
+        struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]), PyArray_Descr *given_descrs[],
+        PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
     Py_INCREF(given_descrs[0]);
     loop_descrs[0] = given_descrs[0];
@@ -86,11 +85,10 @@ string_isnan_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
 }
 
 static NPY_CASTING
-string_isnan_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                 PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-                                 PyArray_Descr *given_descrs[],
-                                 PyArray_Descr *loop_descrs[],
-                                 npy_intp *NPY_UNUSED(view_offset))
+string_isnan_resolve_descriptors(
+        struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]), PyArray_Descr *given_descrs[],
+        PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
     Py_INCREF(given_descrs[0]);
     loop_descrs[0] = given_descrs[0];
@@ -176,9 +174,6 @@ init_ufunc(PyObject *numpy, const char *ufunc_name, PyArray_DTypeMeta **dtypes,
         return -1;
     }
 
-    /*
-     *  Initialize spec for equality
-     */
     PyType_Slot slots[] = {{NPY_METH_resolve_descriptors, resolve_func},
                            {NPY_METH_strided_loop, loop_func},
                            {0, NULL}};

--- a/unytdtype/unytdtype/src/unytdtype_main.c
+++ b/unytdtype/unytdtype/src/unytdtype_main.c
@@ -21,7 +21,7 @@ PyInit__unytdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(6) < 0) {
+    if (import_experimental_dtype_api(7) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
https://github.com/numpy/numpy/pull/23211 changed the publicly visible typedef for `resolve_descriptors_function`. This adapts to the new definition and fixes a compiler warning introduced by the upstream change. I also deleted an outdated comment.