### PR TITLE
Refactor metadatadtype to use ufunc wrapping

### DIFF
--- a/metadatadtype/meson.build
+++ b/metadatadtype/meson.build
@@ -41,7 +41,6 @@ py.install_sources(
 py.extension_module(
   '_metadatadtype_main',
   srcs,
-  c_args: ['-g', '-O0'],
   install: true,
   subdir: 'metadatadtype',
   include_directories: includes

--- a/metadatadtype/metadatadtype/src/dtype.c
+++ b/metadatadtype/metadatadtype/src/dtype.c
@@ -81,15 +81,12 @@ new_metadatadtype_instance(PyObject *metadata)
     return new;
 }
 
-/*
- * This is used to determine the correct dtype to return when operations mix
- * dtypes (I think?). For now just return the first one.
- */
-static MetadataDTypeObject *
-common_instance(MetadataDTypeObject *dtype1, MetadataDTypeObject *dtype2)
+PyArray_Descr *
+common_instance(MetadataDTypeObject *dtype1,
+                MetadataDTypeObject *NPY_UNUSED(dtype2))
 {
     Py_INCREF(dtype1);
-    return dtype1;
+    return (PyArray_Descr *)dtype1;
 }
 
 static PyArray_DTypeMeta *

--- a/metadatadtype/metadatadtype/src/dtype.h
+++ b/metadatadtype/metadatadtype/src/dtype.h
@@ -27,4 +27,8 @@ new_metadatadtype_instance(PyObject *metadata);
 int
 init_metadata_dtype(void);
 
+PyArray_Descr *
+common_instance(MetadataDTypeObject *dtype1,
+                MetadataDTypeObject *NPY_UNUSED(dtype2));
+
 #endif /*_NPY_DTYPE_H*/

--- a/metadatadtype/metadatadtype/src/dtype.h
+++ b/metadatadtype/metadatadtype/src/dtype.h
@@ -31,4 +31,7 @@ PyArray_Descr *
 common_instance(MetadataDTypeObject *dtype1,
                 MetadataDTypeObject *NPY_UNUSED(dtype2));
 
+// from numpy's dtypemeta.h, not publicly available
+#define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))
+
 #endif /*_NPY_DTYPE_H*/

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -51,7 +51,7 @@ PyInit__metadatadtype_main(void)
         goto error;
     }
 
-    if (init_multiply_ufunc() < 0) {
+    if (init_ufuncs() < 0) {
         goto error;
     }
 

--- a/metadatadtype/metadatadtype/src/umath.c
+++ b/metadatadtype/metadatadtype/src/umath.c
@@ -12,96 +12,78 @@
 #include "umath.h"
 
 static int
-metadata_multiply_strided_loop(PyArrayMethod_Context *context,
-                               char *const data[], npy_intp const dimensions[],
-                               npy_intp const strides[], NpyAuxData *auxdata)
+translate_given_descrs_to_double(
+        int nin, int nout, PyArray_DTypeMeta *NPY_UNUSED(wrapped_dtypes[]),
+        PyArray_Descr *given_descrs[], PyArray_Descr *new_descrs[])
 {
-    npy_intp N = dimensions[0];
-    char *in1 = data[0], *in2 = data[1];
-    char *out = data[2];
-    npy_intp in1_stride = strides[0];
-    npy_intp in2_stride = strides[1];
-    npy_intp out_stride = strides[2];
-
-    while (N--) {
-        *(double *)out = *(double *)in1 * *(double *)in2;
-        in1 += in1_stride;
-        in2 += in2_stride;
-        out += out_stride;
+    assert(nin == 2 && nout == 1);
+    for (int i = 0; i < 3; i++) {
+        if (given_descrs[i] == NULL) {
+            new_descrs[i] = NULL;
+        }
+        else {
+            new_descrs[i] = PyArray_DescrFromType(NPY_DOUBLE);
+        }
     }
     return 0;
 }
 
-static NPY_CASTING
-metadata_multiply_resolve_descriptors(PyObject *self,
-                                      PyArray_DTypeMeta *dtypes[],
-                                      PyArray_Descr *given_descrs[],
-                                      PyArray_Descr *loop_descrs[],
-                                      npy_intp *unused)
+static int
+translate_loop_descrs(int nin, int nout,
+                      PyArray_DTypeMeta *NPY_UNUSED(new_dtypes[]),
+                      PyArray_Descr *given_descrs[],
+                      PyArray_Descr *NPY_UNUSED(original_descrs[]),
+                      PyArray_Descr *loop_descrs[])
 {
-    // for now just the take the metadata of the first operand
-    PyObject *meta1 = ((MetadataDTypeObject *)given_descrs[0])->metadata;
-
-    /* Create new DType from the new unit: */
-    loop_descrs[2] = (PyArray_Descr *)new_metadatadtype_instance(meta1);
-    if (loop_descrs[2] == NULL) {
+    assert(nin == 2 && nout == 1);
+    loop_descrs[0] = common_instance((MetadataDTypeObject *)given_descrs[0],
+                                     (MetadataDTypeObject *)given_descrs[1]);
+    if (loop_descrs[0] == NULL) {
         return -1;
     }
-    /* The other operand units can be used as-is: */
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-    Py_INCREF(given_descrs[1]);
-    loop_descrs[1] = given_descrs[1];
-
-    return NPY_NO_CASTING;
+    Py_INCREF(loop_descrs[0]);
+    loop_descrs[1] = loop_descrs[0];
+    Py_INCREF(loop_descrs[0]);
+    loop_descrs[2] = loop_descrs[0];
+    return 0;
 }
 
-/*
- * Function that adds our multiply loop to NumPy's multiply ufunc.
- */
+static PyObject *
+get_ufunc(const char *ufunc_name)
+{
+    PyObject *mod = PyImport_ImportModule("numpy");
+    if (mod == NULL) {
+        return NULL;
+    }
+    PyObject *ufunc = PyObject_GetAttrString(mod, ufunc_name);
+    Py_DECREF(mod);
+    if (ufunc == NULL) {
+        return NULL;
+    }
+    return ufunc;
+}
+
+static int
+add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta *dtypes[3])
+{
+    PyObject *ufunc = get_ufunc(ufunc_name);
+    PyArray_DTypeMeta *wrapped_dtypes[3] = {
+            &PyArray_DoubleDType, &PyArray_DoubleDType, &PyArray_DoubleDType};
+    return PyUFunc_AddWrappingLoop(ufunc, dtypes, wrapped_dtypes,
+                                   &translate_given_descrs_to_double,
+                                   &translate_loop_descrs);
+}
+
 int
-init_multiply_ufunc(void)
+init_ufuncs(void)
 {
-    /*
-     * Get the multiply ufunc:
-     */
-    PyObject *numpy = PyImport_ImportModule("numpy");
-    if (numpy == NULL) {
-        return -1;
-    }
-    PyObject *multiply = PyObject_GetAttrString(numpy, "multiply");
-    Py_DECREF(numpy);
-    if (multiply == NULL) {
-        return -1;
+    PyArray_DTypeMeta *dtypes[3] = {&MetadataDType, &MetadataDType,
+                                    &MetadataDType};
+    if (add_wrapping_loop("multiply", dtypes) == -1) {
+        goto error;
     }
 
-    /*
-     * The initializing "wrap up" code from the slides (plus one error check)
-     */
-    static PyArray_DTypeMeta *dtypes[3] = {&MetadataDType, &MetadataDType,
-                                           &MetadataDType};
-
-    static PyType_Slot slots[] = {
-            {NPY_METH_resolve_descriptors,
-             &metadata_multiply_resolve_descriptors},
-            {NPY_METH_strided_loop, &metadata_multiply_strided_loop},
-            {0, NULL}};
-
-    PyArrayMethod_Spec MultiplySpec = {
-            .name = "metadata_multiply",
-            .nin = 2,
-            .nout = 1,
-            .dtypes = dtypes,
-            .slots = slots,
-            .flags = 0,
-            .casting = NPY_NO_CASTING,
-    };
-
-    /* Register */
-    if (PyUFunc_AddLoopFromSpec(multiply, &MultiplySpec) < 0) {
-        Py_DECREF(multiply);
-        return -1;
-    }
-    Py_DECREF(multiply);
     return 0;
+error:
+    return -1;
 }

--- a/metadatadtype/metadatadtype/src/umath.c
+++ b/metadatadtype/metadatadtype/src/umath.c
@@ -12,39 +12,66 @@
 #include "umath.h"
 
 static int
-translate_given_descrs_to_double(
-        int nin, int nout, PyArray_DTypeMeta *NPY_UNUSED(wrapped_dtypes[]),
-        PyArray_Descr *given_descrs[], PyArray_Descr *new_descrs[])
+translate_given_descrs(int nin, int nout,
+                       PyArray_DTypeMeta *NPY_UNUSED(wrapped_dtypes[]),
+                       PyArray_Descr *given_descrs[],
+                       PyArray_Descr *new_descrs[])
 {
-    assert(nin == 2 && nout == 1);
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < nin + nout; i++) {
         if (given_descrs[i] == NULL) {
             new_descrs[i] = NULL;
         }
         else {
-            new_descrs[i] = PyArray_DescrFromType(NPY_DOUBLE);
+            if (NPY_DTYPE(given_descrs[i]) == &PyArray_BoolDType) {
+                new_descrs[i] = PyArray_DescrFromType(NPY_BOOL);
+            }
+            else {
+                new_descrs[i] = PyArray_DescrFromType(NPY_DOUBLE);
+            }
         }
     }
     return 0;
 }
 
 static int
-translate_loop_descrs(int nin, int nout,
+translate_loop_descrs(int nin, int NPY_UNUSED(nout),
                       PyArray_DTypeMeta *NPY_UNUSED(new_dtypes[]),
                       PyArray_Descr *given_descrs[],
-                      PyArray_Descr *NPY_UNUSED(original_descrs[]),
+                      PyArray_Descr *original_descrs[],
                       PyArray_Descr *loop_descrs[])
 {
-    assert(nin == 2 && nout == 1);
-    loop_descrs[0] = common_instance((MetadataDTypeObject *)given_descrs[0],
-                                     (MetadataDTypeObject *)given_descrs[1]);
-    if (loop_descrs[0] == NULL) {
+    if (nin == 2) {
+        loop_descrs[0] =
+                common_instance((MetadataDTypeObject *)given_descrs[0],
+                                (MetadataDTypeObject *)given_descrs[1]);
+        if (loop_descrs[0] == NULL) {
+            return -1;
+        }
+        Py_INCREF(loop_descrs[0]);
+        loop_descrs[1] = loop_descrs[0];
+        Py_INCREF(loop_descrs[1]);
+        if (NPY_DTYPE(original_descrs[2]) == &PyArray_BoolDType) {
+            loop_descrs[2] = PyArray_DescrFromType(NPY_BOOL);
+        }
+        else {
+            loop_descrs[2] = loop_descrs[0];
+        }
+        Py_INCREF(loop_descrs[2]);
+    }
+    else if (nin == 1) {
+        loop_descrs[0] = given_descrs[0];
+        Py_INCREF(loop_descrs[0]);
+        if (NPY_DTYPE(original_descrs[1]) == &PyArray_BoolDType) {
+            loop_descrs[1] = PyArray_DescrFromType(NPY_BOOL);
+        }
+        else {
+            loop_descrs[1] = loop_descrs[0];
+        }
+        Py_INCREF(loop_descrs[1]);
+    }
+    else {
         return -1;
     }
-    Py_INCREF(loop_descrs[0]);
-    loop_descrs[1] = loop_descrs[0];
-    Py_INCREF(loop_descrs[0]);
-    loop_descrs[2] = loop_descrs[0];
     return 0;
 }
 
@@ -64,22 +91,37 @@ get_ufunc(const char *ufunc_name)
 }
 
 static int
-add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta *dtypes[3])
+add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta **dtypes,
+                  PyArray_DTypeMeta **wrapped_dtypes)
 {
     PyObject *ufunc = get_ufunc(ufunc_name);
-    PyArray_DTypeMeta *wrapped_dtypes[3] = {
-            &PyArray_DoubleDType, &PyArray_DoubleDType, &PyArray_DoubleDType};
-    return PyUFunc_AddWrappingLoop(ufunc, dtypes, wrapped_dtypes,
-                                   &translate_given_descrs_to_double,
-                                   &translate_loop_descrs);
+    if (ufunc == NULL) {
+        return -1;
+    }
+    int res = PyUFunc_AddWrappingLoop(ufunc, dtypes, wrapped_dtypes,
+                                      &translate_given_descrs,
+                                      &translate_loop_descrs);
+    return res;
 }
 
 int
 init_ufuncs(void)
 {
-    PyArray_DTypeMeta *dtypes[3] = {&MetadataDType, &MetadataDType,
-                                    &MetadataDType};
-    if (add_wrapping_loop("multiply", dtypes) == -1) {
+    PyArray_DTypeMeta *binary_orig_dtypes[3] = {&MetadataDType, &MetadataDType,
+                                                &MetadataDType};
+    PyArray_DTypeMeta *binary_wrapped_dtypes[3] = {
+            &PyArray_DoubleDType, &PyArray_DoubleDType, &PyArray_DoubleDType};
+    if (add_wrapping_loop("multiply", binary_orig_dtypes,
+                          binary_wrapped_dtypes) == -1) {
+        goto error;
+    }
+
+    PyArray_DTypeMeta *unary_boolean_dtypes[2] = {&MetadataDType,
+                                                  &PyArray_BoolDType};
+    PyArray_DTypeMeta *unary_boolean_wrapped_dtypes[2] = {&PyArray_DoubleDType,
+                                                          &PyArray_BoolDType};
+    if (add_wrapping_loop("isnan", unary_boolean_dtypes,
+                          unary_boolean_wrapped_dtypes) == -1) {
         goto error;
     }
 

--- a/metadatadtype/metadatadtype/src/umath.c
+++ b/metadatadtype/metadatadtype/src/umath.c
@@ -84,9 +84,7 @@ get_ufunc(const char *ufunc_name)
     }
     PyObject *ufunc = PyObject_GetAttrString(mod, ufunc_name);
     Py_DECREF(mod);
-    if (ufunc == NULL) {
-        return NULL;
-    }
+
     return ufunc;
 }
 

--- a/metadatadtype/metadatadtype/src/umath.h
+++ b/metadatadtype/metadatadtype/src/umath.h
@@ -2,6 +2,6 @@
 #define _NPY_UFUNC_H
 
 int
-init_multiply_ufunc(void);
+init_ufuncs(void);
 
 #endif /*_NPY_UFUNC_H */

--- a/metadatadtype/pyproject.toml
+++ b/metadatadtype/pyproject.toml
@@ -18,3 +18,9 @@ requires-python = ">=3.9.0"
 dependencies = [
     "numpy",
 ]
+
+[tool.meson-python.args]
+dist = []
+setup = ["-Ddebug=true", "-Doptimization=0"]
+compile = []
+install = []

--- a/metadatadtype/tests/test_metadatadtype.py
+++ b/metadatadtype/tests/test_metadatadtype.py
@@ -37,6 +37,14 @@ def test_multiplication():
     assert str(res) == "[2.0 test 2.0 test 2.0 test]"
 
 
+def test_isnan():
+    dtype = MetadataDType("test")
+    num_scalar = MetadataScalar(1, dtype)
+    nan_scalar = MetadataScalar(np.nan, dtype)
+    arr = np.array([num_scalar, nan_scalar, nan_scalar])
+    np.testing.assert_array_equal(np.isnan(arr), np.array([False, True, True]))
+
+
 def test_cast_to_different_metadata():
     dtype = MetadataDType("test")
     scalar = MetadataScalar(1, dtype)
@@ -50,5 +58,5 @@ def test_cast_to_float64():
     dtype = MetadataDType("test")
     scalar = MetadataScalar(1, dtype)
     arr = np.array([scalar, scalar, scalar])
-    conv = arr.astype('float64')
+    conv = arr.astype("float64")
     assert str(conv) == "[1. 1. 1.]"


### PR DESCRIPTION
Rather than implementing ufunc loops manually, it's much more straightforward for metadatadtype to simply wrap float64 ufunc loops. This PR refactors the ufunc implementation in metadatadtype to use the `PyUFunc_AddWrappingLoop` API to do that.

Most of this is adapted from the scaled float dtype in numpy.