### PR TITLE
Add clear loop implementation

### DIFF
--- a/asciidtype/asciidtype/src/asciidtype_main.c
+++ b/asciidtype/asciidtype/src/asciidtype_main.c
@@ -22,7 +22,7 @@ PyInit__asciidtype_main(void)
         return NULL;
     }
 
-    if (import_experimental_dtype_api(8) < 0) {
+    if (import_experimental_dtype_api(9) < 0) {
         return NULL;
     }
 

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -21,7 +21,7 @@ PyInit__metadatadtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(8) < 0) {
+    if (import_experimental_dtype_api(9) < 0) {
         return NULL;
     }
 

--- a/mpfdtype/mpfdtype/src/mpfdtype_main.c
+++ b/mpfdtype/mpfdtype/src/mpfdtype_main.c
@@ -22,7 +22,7 @@ PyInit__mpfdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(8) < 0) {
+    if (import_experimental_dtype_api(9) < 0) {
         return NULL;
     }
 

--- a/quaddtype/quaddtype/src/quaddtype_main.c
+++ b/quaddtype/quaddtype/src/quaddtype_main.c
@@ -23,7 +23,7 @@ PyInit__quaddtype_main(void)
         return NULL;
 
     // Fail to init if the experimental DType API version 5 isn't supported
-    if (import_experimental_dtype_api(8) < 0) {
+    if (import_experimental_dtype_api(9) < 0) {
         PyErr_SetString(PyExc_ImportError,
                         "Error encountered importing the experimental dtype API.");
         return NULL;

--- a/stringdtype/meson.build
+++ b/stringdtype/meson.build
@@ -43,7 +43,6 @@ py.install_sources(
 py.extension_module(
   '_main',
   srcs,
-  c_args: ['-g', '-O0', '-pg'],
   install: true,
   subdir: 'stringdtype',
   include_directories: includes

--- a/stringdtype/pyproject.toml
+++ b/stringdtype/pyproject.toml
@@ -28,3 +28,9 @@ dependencies = [
 [tool.ruff]
 line-length = 79
 per-file-ignores = {"__init__.py" = ["F401"]}
+
+[tool.meson-python.args]
+dist = []
+setup = ["-Ddebug=true", "-Doptimization=0"]
+compile = []
+install = []

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -220,9 +220,10 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
         ss *out_ss = ssnewempty(out_num_bytes);
         if (out_ss == NULL) {
             gil_error(PyExc_MemoryError, "ssnewempty failed");
+            return -1;
         }
         char *out_buf = out_ss->buf;
-        for (int i = 0; i < num_codepoints; i++) {
+        for (size_t i = 0; i < num_codepoints; i++) {
             // get code point
             Py_UCS4 code = in[i];
 

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -21,6 +21,7 @@ new_stringdtype_instance(void)
     new->base.flags |= NPY_NEEDS_INIT;
     new->base.flags |= NPY_LIST_PICKLE;
     new->base.flags |= NPY_ITEM_REFCOUNT;
+    new->base.flags |= NPY_NEEDS_PYAPI;
 
     return new;
 }

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -183,6 +183,7 @@ stringdtype_clear_loop(void *NPY_UNUSED(traverse_context),
     while (size--) {
         if (data != NULL) {
             free(*(ss **)data);
+            *(ss **)data = NULL;
         }
         data += stride;
     }
@@ -199,7 +200,7 @@ stringdtype_get_clear_loop(void *NPY_UNUSED(traverse_context),
                            NpyAuxData **NPY_UNUSED(out_auxdata),
                            NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
+    *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
     *out_loop = &stringdtype_clear_loop;
     return 0;
 }

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -21,7 +21,6 @@ new_stringdtype_instance(void)
     new->base.flags |= NPY_NEEDS_INIT;
     new->base.flags |= NPY_LIST_PICKLE;
     new->base.flags |= NPY_ITEM_REFCOUNT;
-    new->base.flags |= NPY_NEEDS_PYAPI;
 
     return new;
 }

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -20,6 +20,8 @@ new_stringdtype_instance(void)
     new->base.alignment = _Alignof(ss *);
     new->base.flags |= NPY_NEEDS_INIT;
     new->base.flags |= NPY_LIST_PICKLE;
+    new->base.flags |= NPY_ITEM_REFCOUNT;
+    new->base.flags |= NPY_ITEM_IS_POINTER;
 
     return new;
 }
@@ -172,6 +174,36 @@ stringdtype_ensure_canonical(StringDTypeObject *self)
     return self;
 }
 
+static int
+stringdtype_clear_loop(void *NPY_UNUSED(traverse_context),
+                       PyArray_Descr *NPY_UNUSED(descr), char *data,
+                       npy_intp size, npy_intp stride,
+                       NpyAuxData *NPY_UNUSED(auxdata))
+{
+    while (size--) {
+        if (data != NULL) {
+            free(*(ss **)data);
+        }
+        data += stride;
+    }
+
+    return 0;
+}
+
+static int
+stringdtype_get_clear_loop(void *NPY_UNUSED(traverse_context),
+                           PyArray_Descr *NPY_UNUSED(descr),
+                           int NPY_UNUSED(aligned),
+                           npy_intp NPY_UNUSED(fixed_stride),
+                           traverse_loop_function **out_loop,
+                           NpyAuxData **NPY_UNUSED(out_auxdata),
+                           NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
+    *out_loop = &stringdtype_clear_loop;
+    return 0;
+}
+
 static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_common_instance, &common_instance},
         {NPY_DT_common_dtype, &common_dtype},
@@ -181,6 +213,7 @@ static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_getitem, &stringdtype_getitem},
         {NPY_DT_ensure_canonical, &stringdtype_ensure_canonical},
         {NPY_DT_PyArray_ArrFuncs_compare, &compare_strings},
+        {NPY_DT_get_clear_loop, &stringdtype_get_clear_loop},
         {0, NULL}};
 
 static PyObject *

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -21,7 +21,6 @@ new_stringdtype_instance(void)
     new->base.flags |= NPY_NEEDS_INIT;
     new->base.flags |= NPY_LIST_PICKLE;
     new->base.flags |= NPY_ITEM_REFCOUNT;
-    new->base.flags |= NPY_ITEM_IS_POINTER;
 
     return new;
 }

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -29,9 +29,9 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
         return NULL;
     }
 
-    NpyIter *iter =
-            NpyIter_New(arr, NPY_ITER_READONLY | NPY_ITER_EXTERNAL_LOOP,
-                        NPY_KEEPORDER, NPY_NO_CASTING, NULL);
+    NpyIter *iter = NpyIter_New(
+            arr, NPY_ITER_READONLY | NPY_ITER_EXTERNAL_LOOP | NPY_ITER_REFS_OK,
+            NPY_KEEPORDER, NPY_NO_CASTING, NULL);
 
     if (iter == NULL) {
         return NULL;
@@ -90,7 +90,7 @@ PyInit__main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(8) < 0) {
+    if (import_experimental_dtype_api(9) < 0) {
         return NULL;
     }
 

--- a/unytdtype/unytdtype/src/unytdtype_main.c
+++ b/unytdtype/unytdtype/src/unytdtype_main.c
@@ -21,7 +21,7 @@ PyInit__unytdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(8) < 0) {
+    if (import_experimental_dtype_api(9) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
Note that this can't be merged until https://github.com/numpy/numpy/pull/23262 is merged and there's a wheel available to install.

There are a couple other minor cleanups as well, but mostly this implements custom `get_clear_loop` and `clear_loop` implementations, allowing us to call `free` on the embedded references stored in the numpy array before the array is deallocated.

I haven't checked, but this will hopefully fix all memory leaks, although there may be other places we need to call `free` as well. In any case, it makes it much easier to check for those places!