### PR TITLE
Handle possible NULL pointers in the array buffer

### DIFF
--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -135,9 +135,21 @@ stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
 }
 
 static PyObject *
-stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
+stringdtype_getitem(StringDTypeObject *NPY_UNUSED(descr), char **dataptr)
 {
-    PyObject *val_obj = PyUnicode_FromString(((ss *)*dataptr)->buf);
+    char *data;
+
+    // in the future this could represent missing data too, but we'd
+    // need to make it so np.empty and np.zeros take their initial value
+    // from an API hook that doesn't exist yet
+    if (*dataptr == NULL) {
+        data = "\0";
+    }
+    else {
+        data = ((ss *)*dataptr)->buf;
+    }
+
+    PyObject *val_obj = PyUnicode_FromString(data);
 
     if (val_obj == NULL) {
         return NULL;

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -33,9 +33,26 @@ ssdup(const ss *s)
 // does not do any initialization, the caller must
 // initialize and null-terminate the string
 ss *
-ssnewempty(size_t len)
+ssnewemptylen(size_t len)
 {
     ss *ret = (ss *)malloc(sizeof(ss) + sizeof(char) * (len + 1));
     ret->len = len;
     return ret;
+}
+
+ss *
+ssempty(void)
+{
+    return ssnewlen("", 0);
+}
+
+ss *
+empty_if_null(ss **data)
+{
+    if (*data == NULL) {
+        return ssempty();
+    }
+    else {
+        return *data;
+    }
 }

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -21,6 +21,13 @@ ssdup(const ss *s);
 // does not do any initialization, the caller must
 // initialize and null-terminate the string
 ss *
-ssnewempty(size_t len);
+ssnewemptylen(size_t len);
+
+// returns an new heap-allocated empty string
+ss *
+ssnewempty(void);
+
+ss *
+empty_if_null(ss **data);
 
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -30,8 +30,8 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[2];
 
     while (N--) {
-        ss *s1 = *in1;
-        ss *s2 = *in2;
+        ss *s1 = empty_if_null(in1);
+        ss *s2 = empty_if_null(in2);
 
         if (s1->len == s2->len && strncmp(s1->buf, s2->buf, s1->len) == 0) {
             *out = (npy_bool)1;
@@ -39,6 +39,15 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
         else {
             *out = (npy_bool)0;
         }
+
+        if (*in1 == NULL) {
+            free(s1);
+        }
+
+        if (*in2 == NULL) {
+            free(s2);
+        }
+
         in1 += in1_stride;
         in2 += in2_stride;
         out += out_stride;

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -181,3 +181,16 @@ def test_sort(strings):
     np.random.default_rng().shuffle(arr)
     arr.sort()
     np.testing.assert_array_equal(arr, arr_sorted)
+
+
+def test_creation_functions():
+    np.testing.assert_array_equal(
+        np.zeros(3, dtype=StringDType()), ["", "", ""]
+    )
+
+    np.testing.assert_array_equal(
+        np.empty(3, dtype=StringDType()), ["", "", ""]
+    )
+
+    # make sure getitem works too
+    assert np.empty(3, dtype=StringDType())[0] == ""


### PR DESCRIPTION
The discussion around https://github.com/numpy/numpy/pull/23262 made me realize that there can be NULL pointers in the array buffer after `np.zeros` and `np.empty`. This means that we need to check for that case whenever we access an existing string array buffer in the casts and ufuncs.

To support this I added a new helper `empty_if_null`, which returns a new empty static string. I couldn't figure out how to do this in a way that avoids heap allocations because the `ss` struct uses a flexible array member, so I also need to free the resulting empty string later.

It would be possible to avoid this if there was a way for a dtype to supply an initial value for `np.empty` and `np.zeros`.

Alternative suggestions for how to handle this are very welcome.