### PR TITLE
Store contents of static string struct in the array buffer

### DIFF
--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -53,11 +53,17 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[1] / context->descriptors[1]->elsize;
 
     while (N--) {
-        out[0] = ssdup(in[0]);
+        ss *s = empty_if_null(in);
+        out[0] = ssdup(s);
         if (out[0] == NULL) {
             gil_error(PyExc_MemoryError, "ssdup failed");
             return -1;
         }
+
+        if (*in == NULL) {
+            free(s);
+        }
+
         in += in_stride;
         out += out_stride;
     }
@@ -217,9 +223,9 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
             gil_error(PyExc_TypeError, "Invalid unicode code point found");
             return -1;
         }
-        ss *out_ss = ssnewempty(out_num_bytes);
+        ss *out_ss = ssnewemptylen(out_num_bytes);
         if (out_ss == NULL) {
-            gil_error(PyExc_MemoryError, "ssnewempty failed");
+            gil_error(PyExc_MemoryError, "ssnewemptylen failed");
             return -1;
         }
         char *out_buf = out_ss->buf;
@@ -340,8 +346,9 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
     long max_out_size = (context->descriptors[1]->elsize) / 4;
 
     while (N--) {
-        unsigned char *this_string = (unsigned char *)((*in)->buf);
-        size_t n_bytes = (*in)->len;
+        ss *s = empty_if_null(in);
+        unsigned char *this_string = (unsigned char *)(s->buf);
+        size_t n_bytes = s->len;
         size_t tot_n_bytes = 0;
 
         for (int i = 0; i < max_out_size; i++) {
@@ -363,6 +370,11 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
                 break;
             }
         }
+
+        if (*in == NULL) {
+            free(s);
+        }
+
         in += in_stride;
         out += out_stride;
     }

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -55,7 +55,7 @@ string_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
     while (N--) {
         load_string(in, &s);
         os = (ss *)out;
-        if (ssdup(s, os) == -1) {
+        if (ssdup(s, os) < 0) {
             gil_error(PyExc_MemoryError, "ssdup failed");
             return -1;
         }
@@ -218,7 +218,7 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
             return -1;
         }
         ss *out_ss = (ss *)out;
-        if (ssnewemptylen(out_num_bytes, out_ss) == -1) {
+        if (ssnewemptylen(out_num_bytes, out_ss) < 0) {
             gil_error(PyExc_MemoryError, "ssnewemptylen failed");
             return -1;
         }

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -54,7 +54,7 @@ string_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
 
     while (N--) {
         load_string(in, &s);
-        load_string(out, &os);
+        os = (ss *)out;
         if (ssdup(s, os) == -1) {
             gil_error(PyExc_MemoryError, "ssdup failed");
             return -1;

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -125,9 +125,11 @@ stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
 
     // copies contents of val into item_val->buf
     int res = ssnewlen(val, length, (ss *)dataptr);
+
     // val_obj must stay alive until here to ensure *val* doesn't get
     // deallocated
     Py_DECREF(val_obj);
+
     if (res == -1) {
         PyErr_NoMemory();
         return -1;
@@ -137,7 +139,6 @@ stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
         assert(0);
     }
 
-    Py_DECREF(val_obj);
     return 0;
 }
 

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -136,9 +136,21 @@ stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
 }
 
 static PyObject *
-stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
+stringdtype_getitem(StringDTypeObject *NPY_UNUSED(descr), char **dataptr)
 {
-    PyObject *val_obj = PyUnicode_FromString(((ss *)*dataptr)->buf);
+    char *data;
+
+    // in the future this could represent missing data too, but we'd
+    // need to make it so np.empty and np.zeros take their initial value
+    // from an API hook that doesn't exist yet
+    if (*dataptr == NULL) {
+        data = "\0";
+    }
+    else {
+        data = ((ss *)*dataptr)->buf;
+    }
+
+    PyObject *val_obj = PyUnicode_FromString(data);
 
     if (val_obj == NULL) {
         return NULL;

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -50,16 +50,15 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
 
     // initialize with the size of the internal buffer
     size_t memory_usage = PyArray_NBYTES(arr);
-    size_t struct_size = sizeof(ss);
 
     do {
-        ss **in = (ss **)*dataptr;
-        npy_intp stride = *strideptr / descr->elsize;
+        char *in = dataptr[0];
+        npy_intp stride = *strideptr;
         npy_intp count = *innersizeptr;
 
         while (count--) {
             // +1 byte for the null terminator
-            memory_usage += (*in)->len + struct_size + 1;
+            memory_usage += ((ss *)in)->len + 1;
             in += stride;
         }
 

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -1,58 +1,76 @@
 #include "static_string.h"
 
-// allocates a new ss string of length len, filling with the contents of init
-ss *
-ssnewlen(const char *init, size_t len)
+int
+ssnewlen(const char *init, size_t len, ss *to_init)
 {
-    // one extra byte for null terminator
-    ss *ret = (ss *)malloc(sizeof(ss) + sizeof(char) * (len + 1));
-
-    if (ret == NULL) {
-        return NULL;
+    if ((to_init->buf != NULL) || (to_init->len != 0)) {
+        return -1;
     }
 
-    ret->len = len;
+    // one extra byte for null terminator
+    char *ret_buf = (char *)malloc(sizeof(char) * (len + 1));
+
+    if (ret_buf == NULL) {
+        return -1;
+    }
+
+    to_init->len = len;
 
     if (len > 0) {
-        memcpy(ret->buf, init, len);
+        memcpy(ret_buf, init, len);
     }
 
-    ret->buf[len] = '\0';
+    ret_buf[len] = '\0';
 
-    return ret;
+    to_init->buf = ret_buf;
+
+    return 0;
 }
 
-// returns a new heap-allocated copy of input string *s*
-ss *
-ssdup(const ss *s)
+void
+ssfree(ss *str)
 {
-    return ssnewlen(s->buf, s->len);
+    if (str->buf != NULL) {
+        free(str->buf);
+        str->buf = NULL;
+    }
+    str->len = 0;
 }
 
-// returns a new, empty string of length len
-// does not do any initialization, the caller must
-// initialize and null-terminate the string
-ss *
-ssnewemptylen(size_t len)
+int
+ssdup(ss *in, ss *out)
 {
-    ss *ret = (ss *)malloc(sizeof(ss) + sizeof(char) * (len + 1));
-    ret->len = len;
-    return ret;
+    return ssnewlen(in->buf, in->len, out);
 }
 
-ss *
-ssempty(void)
+int
+ssnewemptylen(size_t num_bytes, ss *out)
 {
-    return ssnewlen("", 0);
+    if (out->len != 0 || out->buf != NULL) {
+        return -1;
+    }
+
+    char *buf = (char *)malloc(sizeof(char) * (num_bytes + 1));
+
+    if (buf == NULL) {
+        return -1;
+    }
+
+    out->buf = buf;
+    out->len = num_bytes;
+
+    return 0;
 }
 
-ss *
-empty_if_null(ss **data)
+static ss EMPTY = {0, "\0"};
+
+void
+load_string(char *data, ss **out)
 {
-    if (*data == NULL) {
-        return ssempty();
+    if (data == NULL) {
+        *out = &EMPTY;
     }
     else {
-        return *data;
+        *out = (ss *)data;
     }
 }

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -67,10 +67,11 @@ static ss EMPTY = {0, "\0"};
 void
 load_string(char *data, ss **out)
 {
-    if (data == NULL) {
+    ss *ss_d = (ss *)data;
+    if (ss_d->len == 0) {
         *out = &EMPTY;
     }
     else {
-        *out = (ss *)data;
+        *out = ss_d;
     }
 }

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -4,7 +4,7 @@ int
 ssnewlen(const char *init, size_t len, ss *to_init)
 {
     if ((to_init->buf != NULL) || (to_init->len != 0)) {
-        return -1;
+        return -2;
     }
 
     // one extra byte for null terminator
@@ -47,7 +47,7 @@ int
 ssnewemptylen(size_t num_bytes, ss *out)
 {
     if (out->len != 0 || out->buf != NULL) {
-        return -1;
+        return -2;
     }
 
     char *buf = (char *)malloc(sizeof(char) * (num_bytes + 1));

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -33,9 +33,26 @@ ssdup(const ss *s)
 // does not do any initialization, the caller must
 // initialize and null-terminate the string
 ss *
-ssnewempty(size_t len)
+ssnewemptylen(size_t len)
 {
     ss *ret = (ss *)malloc(sizeof(ss) + sizeof(char) * (len + 1));
     ret->len = len;
     return ret;
+}
+
+ss *
+ssempty(void)
+{
+    return ssnewlen("", 0);
+}
+
+ss *
+empty_if_null(ss **data)
+{
+    if (*data == NULL) {
+        return ssempty();
+    }
+    else {
+        return *data;
+    }
 }

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -6,28 +6,40 @@
 
 typedef struct ss {
     size_t len;
-    char buf[];
+    char *buf;
 } ss;
 
-// allocates a new ss string of length len, filling with the contents of init
-ss *
-ssnewlen(const char *init, size_t len);
+// Allocates a new buffer for *to_init*, filling with the copied contents of
+// *init* and sets *to_init->len* to *len*.
+int
+ssnewlen(const char *init, size_t len, ss *to_init);
 
-// returns a new heap-allocated copy of input string *s*
-ss *
-ssdup(const ss *s);
+// Frees the internal string buffer held by *str*. If str->buf is NULL, does
+// nothing.
+void
+ssfree(ss *str);
 
-// returns a new, empty string of length len
-// does not do any initialization, the caller must
-// initialize and null-terminate the string
-ss *
-ssnewemptylen(size_t len);
+// copies the contents out *in* into *out*. Allocates a new string buffer for
+// *out*, checks that *out->buf* is NULL and *out->len* is zero and errors
+// otherwise. Also errors if malloc fails.
+int
+ssdup(ss *in, ss *out);
 
-// returns an new heap-allocated empty string
-ss *
-ssnewempty(void);
+// Allocates a new string buffer for *out* with enough capacity to store
+// *num_bytes* of text. The actual allocation is num_bytes + 1 bytes, to
+// account for the null terminator. Does not do any initialization, the caller
+// must initialize and null-terminate the string buffer. Errors if *out*
+// already contains data or if malloc fails.
+int
+ssnewemptylen(size_t num_bytes, ss *out);
 
-ss *
-empty_if_null(ss **data);
+// Interpret the contents of buffer *data* as an ss struct and set *out* to
+// that struct. If *data* is NULL, set *out* to point to a statically
+// allocated, empty SS struct. Since this function may set *out* to point to
+// statically allocated data, do not ever free memory owned by an output of
+// this function. That means this function is most useful for read-only
+// applications.
+void
+load_string(char *data, ss **out);
 
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -10,26 +10,27 @@ typedef struct ss {
 } ss;
 
 // Allocates a new buffer for *to_init*, filling with the copied contents of
-// *init* and sets *to_init->len* to *len*.
+// *init* and sets *to_init->len* to *len*. Returns -1 if malloc fails and -2
+// if *to_init* is not empty. Returns 0 on success.
 int
 ssnewlen(const char *init, size_t len, ss *to_init);
 
-// Frees the internal string buffer held by *str*. If str->buf is NULL, does
-// nothing.
+// Sets len to 0 and if str->buf is not already NULL, frees it and sets it to
+// NULL. Cannot fail.
 void
 ssfree(ss *str);
 
 // copies the contents out *in* into *out*. Allocates a new string buffer for
-// *out*, checks that *out->buf* is NULL and *out->len* is zero and errors
-// otherwise. Also errors if malloc fails.
+// *out*. Returns -1 if malloc fails and -2 if *out* is not empty. Returns 0 on
+// success.
 int
 ssdup(ss *in, ss *out);
 
 // Allocates a new string buffer for *out* with enough capacity to store
 // *num_bytes* of text. The actual allocation is num_bytes + 1 bytes, to
 // account for the null terminator. Does not do any initialization, the caller
-// must initialize and null-terminate the string buffer. Errors if *out*
-// already contains data or if malloc fails.
+// must initialize and null-terminate the string buffer. Returns -1 if malloc
+// fails and -2 if *out* is not empty. Returns 0 on success.
 int
 ssnewemptylen(size_t num_bytes, ss *out);
 

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -21,6 +21,13 @@ ssdup(const ss *s);
 // does not do any initialization, the caller must
 // initialize and null-terminate the string
 ss *
-ssnewempty(size_t len);
+ssnewemptylen(size_t len);
+
+// returns an new heap-allocated empty string
+ss *
+ssnewempty(void);
+
+ss *
+empty_if_null(ss **data);
 
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -14,38 +14,30 @@
 #include "umath.h"
 
 static int
-string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
-                          npy_intp const dimensions[],
+string_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                          char *const data[], npy_intp const dimensions[],
                           npy_intp const strides[],
                           NpyAuxData *NPY_UNUSED(auxdata))
 {
     npy_intp N = dimensions[0];
-    ss **in1 = (ss **)data[0];
-    ss **in2 = (ss **)data[1];
+    char *in1 = data[0];
+    char *in2 = data[1];
     npy_bool *out = (npy_bool *)data[2];
-    // strides are in bytes but pointer offsets are in pointer widths, so
-    // divide by the element size (one pointer width) to get the pointer offset
-    npy_intp in1_stride = strides[0] / context->descriptors[0]->elsize;
-    npy_intp in2_stride = strides[1] / context->descriptors[1]->elsize;
+    npy_intp in1_stride = strides[0];
+    npy_intp in2_stride = strides[1];
     npy_intp out_stride = strides[2];
 
+    ss *s1 = NULL, *s2 = NULL;
+
     while (N--) {
-        ss *s1 = empty_if_null(in1);
-        ss *s2 = empty_if_null(in2);
+        load_string(in1, &s1);
+        load_string(in2, &s2);
 
         if (s1->len == s2->len && strncmp(s1->buf, s2->buf, s1->len) == 0) {
             *out = (npy_bool)1;
         }
         else {
             *out = (npy_bool)0;
-        }
-
-        if (*in1 == NULL) {
-            free(s1);
-        }
-
-        if (*in2 == NULL) {
-            free(s2);
         }
 
         in1 += in1_stride;

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -30,8 +30,8 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[2];
 
     while (N--) {
-        ss *s1 = *in1;
-        ss *s2 = *in2;
+        ss *s1 = empty_if_null(in1);
+        ss *s2 = empty_if_null(in2);
 
         if (s1->len == s2->len && strncmp(s1->buf, s2->buf, s1->len) == 0) {
             *out = (npy_bool)1;
@@ -39,6 +39,15 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
         else {
             *out = (npy_bool)0;
         }
+
+        if (*in1 == NULL) {
+            free(s1);
+        }
+
+        if (*in2 == NULL) {
+            free(s2);
+        }
+
         in1 += in1_stride;
         in2 += in2_stride;
         out += out_stride;

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -181,3 +181,16 @@ def test_sort(strings):
     np.random.default_rng().shuffle(arr)
     arr.sort()
     np.testing.assert_array_equal(arr, arr_sorted)
+
+
+def test_creation_functions():
+    np.testing.assert_array_equal(
+        np.zeros(3, dtype=StringDType()), ["", "", ""]
+    )
+
+    np.testing.assert_array_equal(
+        np.empty(3, dtype=StringDType()), ["", "", ""]
+    )
+
+    # make sure getitem works too
+    assert np.empty(3, dtype=StringDType())[0] == ""


### PR DESCRIPTION
This is a followup for #41, since I had to make a number of extensive changes relative to what that PR originally proposed, I issued a new PR instead to hopefully make this clearer.

Instead of using flexible-length arrays, the `ss` struct now looks like this:

```
typedef struct ss {
    size_t len;
    char *buf;
} ss;
```

Rather than store a pointer to an `ss` struct in the array buffer, this refactors things so we instead store the contents of the `ss` struct in the array buffer. This reduces the amount of pointer indirection we need to do to get access to the `ss` struct data and also makes it much easier to deal with empty strings, since with this new definition `((ss*)NULL)->len` is zero by construction.

Instead of `malloc`ing storage for the entire struct on the heap, we now only `malloc` space for the string buffer, and the caller of functions that allocate memory are responsible for handling memory for the `ss` struct.

To handle this change, I had to rewrite the static_string API to accept pointers to `ss` instances instead of returning them. I also added a new `load_string` helper that returns either a read-only view onto an `ss` struct, or if the struct is `NULL`, returns a view onto a statically allocated empty struct.