### PR TITLE
Add `argmax` `PyArray_ArrFunc`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,13 +73,11 @@ repos:
       - id: check-added-large-files
       - id: check-ast
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.217
+    rev: v0.0.254
     hooks:
     - id: ruff
-      # Respect `exclude` and `extend-exclude` settings.
-      args: ["--force-exclude"]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier
         types:
@@ -88,7 +86,7 @@ repos:
             yaml,
           ]
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
@@ -99,7 +97,7 @@ repos:
         name: isort (pyi)
         types: [pyi]
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         name: 'black for asciidtype'

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -212,3 +212,33 @@ def test_creation_functions():
 
 def test_is_numeric():
     assert not StringDType._is_numeric
+
+
+@pytest.mark.parametrize(
+    "strings",
+    [
+        ["left", "right", "leftovers", "righty", "up", "down"],
+        ["🤣🤣", "🤣", "📵", "😰"],
+        ["🚜", "🙃", "😾"],
+        ["😹", "🚠", "🚌"],
+        ["A¢☃€ 😊", " A☃€¢😊", "☃€😊 A¢", "😊☃A¢ €"],
+    ],
+)
+def test_argmax(strings):
+    """Test that argmax matches what python calculates as the argmax."""
+    arr = np.array(strings, dtype=StringDType())
+    assert np.argmax(arr) == strings.index(max(strings))
+
+
+@pytest.mark.parametrize(
+    "arrfunc,expected",
+    [
+        [np.sort, np.empty(10, dtype=StringDType())],
+        [np.nonzero, (np.array([], dtype=np.int64),)],
+        [np.argmax, 0],
+    ],
+)
+def test_arrfuncs_empty(arrfunc, expected):
+    arr = np.empty(10, dtype=StringDType())
+    result = arrfunc(arr)
+    np.testing.assert_array_equal(result, expected, strict=True)


### PR DESCRIPTION
This PR adds support for `argmax`. I've also modified the signature of the `PyArray_CompareFunc` to match the documentation. Additionally, `compare` is now safe against elements with `NULL` data, e.g. `x = np.empty(10); x.sort()` is now safe.

Finally, there was an issue with `isort` in the pre-commit hooks. Autoupdating the hooks resolves this.