### PR TITLE
Add argmin PyArray_ArrFunc

### DIFF
--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -203,6 +203,21 @@ argmax(void *data, npy_intp n, npy_intp *max_ind, void *arr)
     return 0;
 }
 
+// PyArray_ArgFunc
+// The min element is the one with the lowest unicode code point.
+int
+argmin(void *data, npy_intp n, npy_intp *min_ind, void *arr)
+{
+    ss *dptr = (ss *)data;
+    *min_ind = 0;
+    for (int i = 1; i < n; i++) {
+        if (compare(&dptr[i], &dptr[*min_ind], arr) < 0) {
+            *min_ind = i;
+        }
+    }
+    return 0;
+}
+
 static StringDTypeObject *
 stringdtype_ensure_canonical(StringDTypeObject *self)
 {
@@ -252,6 +267,7 @@ static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_PyArray_ArrFuncs_nonzero, &nonzero},
         {NPY_DT_PyArray_ArrFuncs_compare, &compare},
         {NPY_DT_PyArray_ArrFuncs_argmax, &argmax},
+        {NPY_DT_PyArray_ArrFuncs_argmin, &argmin},
         {NPY_DT_get_clear_loop, &stringdtype_get_clear_loop},
         {0, NULL}};
 

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -225,9 +225,10 @@ def test_is_numeric():
     ],
 )
 def test_argmax(strings):
-    """Test that argmax matches what python calculates as the argmax."""
+    """Test that argmax/argmin matches what python calculates."""
     arr = np.array(strings, dtype=StringDType())
     assert np.argmax(arr) == strings.index(max(strings))
+    assert np.argmin(arr) == strings.index(min(strings))
 
 
 @pytest.mark.parametrize(
@@ -236,6 +237,7 @@ def test_argmax(strings):
         [np.sort, np.empty(10, dtype=StringDType())],
         [np.nonzero, (np.array([], dtype=np.int64),)],
         [np.argmax, 0],
+        [np.argmin, 0],
     ],
 )
 def test_arrfuncs_empty(arrfunc, expected):
@@ -243,7 +245,7 @@ def test_arrfuncs_empty(arrfunc, expected):
     result = arrfunc(arr)
     np.testing.assert_array_equal(result, expected, strict=True)
 
-    
+
 @pytest.mark.parametrize(
     ("string_list", "cast_answer", "any_answer", "all_answer"),
     [


### PR DESCRIPTION
This PR adds support for the `argmin` `PyArray_ArrFunc`. `argmax` tests have been modified to check `argmin` as well.