### PR TITLE
Fix string-to-string cast when the output array is non-null

### DIFF
--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -57,6 +57,7 @@ string_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
     while (N--) {
         load_string(in, &s);
         os = (ss *)out;
+        ssfree(os);
         if (ssdup(s, os) < 0) {
             gil_error(PyExc_MemoryError, "ssdup failed");
             return -1;

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -261,3 +261,16 @@ def test_bool_cast(string_list, cast_answer, any_answer, all_answer):
 
     assert np.any(sarr) == any_answer
     assert np.all(sarr) == all_answer
+
+
+def test_take(string_list):
+    sarr = np.array(string_list, dtype=StringDType())
+    out = np.empty(len(string_list), dtype=StringDType())
+    res = sarr.take(np.arange(len(string_list)), out=out)
+    np.testing.assert_array_equal(sarr, res)
+    np.testing.assert_array_equal(res, out)
+
+    # make sure it also works for out that isn't empty
+    out[0] = "hello"
+    res = sarr.take(np.arange(len(string_list)), out=out)
+    np.testing.assert_array_equal(res, out)


### PR DESCRIPTION
Creating a `pandas.Series` from a `pandas.Categorical` goes through a code path that uses `take` with an `out` parameter. It turns out that this operation ultimately does a cast from `StringDType` to `StringDType`, with the output of the cast set to the `out` array in the `take` call. This currently fails because we end up passing `ssdup` a non-null output string:

```
import os
os.environ["NUMPY_EXPERIMENTAL_DTYPE_API"] = "1"

from stringdtype import StringDType
import pandas._testing as tm
from pandas import Categorical, Series

series_arr = tm.rands_array(nchars=10, size=10**5).astype(StringDType)
series_cat_arr = Categorical(series_arr)
Series(series_cat_arr, dtype=StringDType())
```

```
Traceback (most recent call last):
  File "/home/nathan/Documents/numpy-experiments/test-pandas.py", line 22, in <module>
    Series(series_cat_arr, dtype=StringDType())
  File "/home/nathan/Documents/pandas/pandas/core/series.py", line 497, in __init__
    data = sanitize_array(data, index, dtype, copy)
  File "/home/nathan/Documents/pandas/pandas/core/construction.py", line 550, in sanitize_array
    subarr = data.astype(dtype, copy=copy)
  File "/home/nathan/Documents/pandas/pandas/core/arrays/categorical.py", line 546, in astype
    result = take_nd(
  File "/home/nathan/Documents/pandas/pandas/core/array_algos/take.py", line 118, in take_nd
    return _take_nd_ndarray(arr, indexer, axis, fill_value, allow_fill)
  File "/home/nathan/Documents/pandas/pandas/core/array_algos/take.py", line 163, in _take_nd_ndarray
    func(arr, indexer, out, fill_value)
  File "/home/nathan/Documents/pandas/pandas/core/array_algos/take.py", line 346, in func
    _take_nd_object(
  File "/home/nathan/Documents/pandas/pandas/core/array_algos/take.py", line 529, in _take_nd_object
    arr.take(indexer, axis=axis, out=out)
MemoryError: ssdup failed
```

The fix is to free the string before calling `ssdup`. I suspect that similar things would happen if anyone tried to use the `out` parameter of any other numpy function or ufunc, but since we haven't implemented many ufuncs this hasn't come up until now.