### PR TITLE
Add PyArray_FillWithScalarFunc to support arr.fill()

### DIFF
--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -218,6 +218,19 @@ argmin(void *data, npy_intp n, npy_intp *min_ind, void *arr)
     return 0;
 }
 
+// PyArray_FillWithScalarFunc
+// Fill an array with a scalar value.
+int
+fillwithscalar(void *buffer, npy_intp length, void *value,
+               void *NPY_UNUSED(arr))
+{
+    ss *dptr = (ss *)buffer;
+    for (int i = 0; i < length; i++) {
+        dptr[i] = *(ss *)value;
+    }
+    return 0;
+}
+
 static StringDTypeObject *
 stringdtype_ensure_canonical(StringDTypeObject *self)
 {
@@ -268,6 +281,7 @@ static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_PyArray_ArrFuncs_compare, &compare},
         {NPY_DT_PyArray_ArrFuncs_argmax, &argmax},
         {NPY_DT_PyArray_ArrFuncs_argmin, &argmin},
+        {NPY_DT_PyArray_ArrFuncs_fillwithscalar, &fillwithscalar},
         {NPY_DT_get_clear_loop, &stringdtype_get_clear_loop},
         {0, NULL}};
 

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -246,6 +246,16 @@ def test_arrfuncs_empty(arrfunc, expected):
     np.testing.assert_array_equal(result, expected, strict=True)
 
 
+def test_fillwithscalar(string_list):
+    """Test that ndarray.fill casts the fill value and fills the array."""
+    arr = np.array(string_list, dtype=StringDType())
+    arr.fill("testscalar")
+    np.testing.assert_array_equal(
+        arr,
+        np.array(["testscalar"] * len(arr), dtype=StringDType()),
+    )
+
+
 @pytest.mark.parametrize(
     ("string_list", "cast_answer", "any_answer", "all_answer"),
     [


### PR DESCRIPTION
This PR adds support for the `arr.fill('blah')` `PyArray_ArrFunc` for the `StringDType`. A simple test was added to check that it works.