### PR TITLE
Add min and max ufuncs

### DIFF
--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -26,6 +26,9 @@ new_stringdtype_instance(void);
 int
 init_string_dtype(void);
 
+int
+compare(void *, void *, void *);
+
 // from dtypemeta.h, not public in numpy
 #define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))
 


### PR DESCRIPTION
This PR adds `min` and `max` ufuncs for the `StringDType`. This is pretty cool because these aren't supported for the fixed length unicode dtypes. This PR adds an `ssset` function, which is similar to `ssdup`, except it doesn't require the output `ss *` to have `len == 0` and `buf == NULL`. Instead, `ssset(in, out)` will copy the input to the output using `realloc` to resize the buffer (or allocating new space if needed). @ngoldbaum I get the sense that this is moving in the right direction but there is enough overlap with `ssdup` that I could also see room for some refactoring here. Let me know what you think.