### PR TITLE
Initial support for missing data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         language: system
         require_serial: true
         entry: |
-          bash -c 'cd metadatadtype && mkdir -p build && pip install build meson-python patchelf wheel && python -m build --wheel --no-isolation -Cbuilddir=build';
+          bash -c 'cd metadatadtype && mkdir -p build && pip install build meson-python patchelf wheel && meson setup build && python -m build --wheel --no-isolation -Cbuilddir=build';
         fail_fast: false
       - id: generate-compilation-database-asciidtype
         name: Generate compilation database [asciidtype]
@@ -15,7 +15,7 @@ repos:
         language: system
         require_serial: true
         entry: |
-          bash -c 'cd asciidtype && mkdir -p build && pip install build meson-python patchelf wheel && python -m build --wheel --no-isolation -Cbuilddir=build';
+          bash -c 'cd asciidtype && mkdir -p build && pip install build meson-python patchelf wheel && meson setup build && python -m build --wheel --no-isolation -Cbuilddir=build';
         fail_fast: false
       - id: generate-compilation-database-quaddtype
         name: Generate compilation database [quaddtype]
@@ -23,7 +23,7 @@ repos:
         language: system
         require_serial: true
         entry: |
-          bash -c 'cd quaddtype && mkdir -p build && pip install build meson-python patchelf wheel && python -m build --wheel --no-isolation -Cbuilddir=build';
+          bash -c 'cd quaddtype && mkdir -p build && pip install build meson-python patchelf wheel && meson setup build && python -m build --wheel --no-isolation -Cbuilddir=build';
         fail_fast: false
       - id: generate-compilation-database-unytdtype
         name: Generate compilation database [unytdtype]
@@ -31,7 +31,7 @@ repos:
         language: system
         require_serial: true
         entry: |
-          bash -c 'cd unytdtype && mkdir -p build && pip install build meson-python patchelf wheel && python -m build --wheel --no-isolation -Cbuilddir=build';
+          bash -c 'cd unytdtype && mkdir -p build && pip install build meson-python patchelf wheel && meson setup build && python -m build --wheel --no-isolation -Cbuilddir=build';
         fail_fast: false
       - id: generate-compilation-database-stringdtype
         name: Generate compilation database [stringdtype]
@@ -39,7 +39,7 @@ repos:
         language: system
         require_serial: true
         entry: |
-          bash -c 'cd stringdtype && mkdir -p build && pip install build meson-python patchelf wheel && python -m build --wheel --no-isolation -Cbuilddir=build';
+          bash -c 'cd stringdtype && mkdir -p build && pip install build meson-python patchelf wheel && meson setup build && python -m build --wheel --no-isolation -Cbuilddir=build';
         fail_fast: false
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5

--- a/asciidtype/asciidtype/src/asciidtype_main.c
+++ b/asciidtype/asciidtype/src/asciidtype_main.c
@@ -22,7 +22,7 @@ PyInit__asciidtype_main(void)
         return NULL;
     }
 
-    if (import_experimental_dtype_api(9) < 0) {
+    if (import_experimental_dtype_api(10) < 0) {
         return NULL;
     }
 

--- a/asciidtype/meson.build
+++ b/asciidtype/meson.build
@@ -35,7 +35,8 @@ py.install_sources(
     'asciidtype/__init__.py',
     'asciidtype/scalar.py'
   ],
-  subdir: 'asciidtype'
+  subdir: 'asciidtype',
+  pure: false
 )
 
 py.extension_module(

--- a/metadatadtype/meson.build
+++ b/metadatadtype/meson.build
@@ -35,7 +35,8 @@ py.install_sources(
     'metadatadtype/__init__.py',
     'metadatadtype/scalar.py'
   ],
-  subdir: 'metadatadtype'
+  subdir: 'metadatadtype',
+  pure: false
 )
 
 py.extension_module(

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -21,7 +21,7 @@ PyInit__metadatadtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(9) < 0) {
+    if (import_experimental_dtype_api(10) < 0) {
         return NULL;
     }
 

--- a/mpfdtype/meson.build
+++ b/mpfdtype/meson.build
@@ -46,7 +46,8 @@ py.install_sources(
   [
     'mpfdtype/__init__.py',
   ],
-  subdir: 'mpfdtype'
+  subdir: 'mpfdtype',
+  pure: false
 )
 
 py.extension_module(

--- a/mpfdtype/mpfdtype/src/mpfdtype_main.c
+++ b/mpfdtype/mpfdtype/src/mpfdtype_main.c
@@ -22,7 +22,7 @@ PyInit__mpfdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(9) < 0) {
+    if (import_experimental_dtype_api(10) < 0) {
         return NULL;
     }
 

--- a/quaddtype/meson.build
+++ b/quaddtype/meson.build
@@ -33,7 +33,8 @@ py.install_sources(
     'quaddtype/__init__.py',
     'quaddtype/quadscalar.py'
   ],
-  subdir: 'quaddtype'
+  subdir: 'quaddtype',
+  pure: false
 )
 
 py.extension_module(

--- a/quaddtype/quaddtype/src/quaddtype_main.c
+++ b/quaddtype/quaddtype/src/quaddtype_main.c
@@ -23,7 +23,7 @@ PyInit__quaddtype_main(void)
         return NULL;
 
     // Fail to init if the experimental DType API version 5 isn't supported
-    if (import_experimental_dtype_api(9) < 0) {
+    if (import_experimental_dtype_api(10) < 0) {
         PyErr_SetString(PyExc_ImportError,
                         "Error encountered importing the experimental dtype API.");
         return NULL;

--- a/stringdtype/meson.build
+++ b/stringdtype/meson.build
@@ -38,7 +38,8 @@ py.install_sources(
     'stringdtype/scalar.py',
     'stringdtype/missing.py',
   ],
-  subdir: 'stringdtype'
+  subdir: 'stringdtype',
+  pure: false
 )
 
 py.extension_module(

--- a/stringdtype/meson.build
+++ b/stringdtype/meson.build
@@ -35,7 +35,8 @@ srcs = [
 py.install_sources(
   [
     'stringdtype/__init__.py',
-    'stringdtype/scalar.py'
+    'stringdtype/scalar.py',
+    'stringdtype/missing.py',
   ],
   subdir: 'stringdtype'
 )

--- a/stringdtype/pyproject.toml
+++ b/stringdtype/pyproject.toml
@@ -31,6 +31,6 @@ per-file-ignores = {"__init__.py" = ["F401"]}
 
 [tool.meson-python.args]
 dist = []
-setup = ["-Ddebug=true", "-Doptimization=2"]
+setup = ["-Ddebug=true", "-Doptimization=0"]
 compile = []
 install = []

--- a/stringdtype/stringdtype/__init__.py
+++ b/stringdtype/stringdtype/__init__.py
@@ -2,10 +2,12 @@
 
 """
 
+from .missing import NA  # isort: skip
 from .scalar import StringScalar  # isort: skip
 from ._main import StringDType, _memory_usage
 
 __all__ = [
+    "NA",
     "StringDType",
     "StringScalar",
     "_memory_usage",

--- a/stringdtype/stringdtype/missing.py
+++ b/stringdtype/stringdtype/missing.py
@@ -1,0 +1,6 @@
+class NAType:
+    def __repr__(self):
+        return "stringdtype.NA"
+
+
+NA = NAType()

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -152,6 +152,7 @@ stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
     }
 
     if (eq_res == 1) {
+        // NULL is the representation of NA in the array buffer
         sdata = NULL;
     }
     else {
@@ -233,17 +234,11 @@ compare(void *a, void *b, void *NPY_UNUSED(arr))
     ss *ss_b = (ss *)b;
     int a_is_null = ss_isnull(ss_a);
     int b_is_null = ss_isnull(ss_b);
-    if (a_is_null || b_is_null) {
-        // numpy sorts NaNs to the end of the array
-        // pandas sorts NAs to the end as well
-        // so we follow that behavior here
-        if (!b_is_null) {
-            return 1;
-        }
-        else if (!a_is_null) {
-            return -1;
-        }
-        return 0;
+    if (a_is_null) {
+        return 1;
+    }
+    else if (b_is_null) {
+        return -1;
     }
     return strcmp(ss_a->buf, ss_b->buf);
 }

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -4,6 +4,8 @@
 #include "static_string.h"
 
 PyTypeObject *StringScalar_Type = NULL;
+static PyTypeObject *StringNA_Type = NULL;
+static PyObject *NA_OBJ = NULL;
 
 /*
  * Internal helper to create new instances
@@ -80,14 +82,35 @@ string_discover_descriptor_from_pyobject(PyArray_DTypeMeta *NPY_UNUSED(cls),
 static PyObject *
 get_value(PyObject *scalar)
 {
-    PyObject *ret_bytes = NULL;
+    PyObject *ret = NULL;
     PyTypeObject *scalar_type = Py_TYPE(scalar);
     // FIXME: handle bytes too
     if ((scalar_type == &PyUnicode_Type) ||
         (scalar_type == StringScalar_Type)) {
         // attempt to decode as UTF8
-        ret_bytes = PyUnicode_AsUTF8String(scalar);
-        if (ret_bytes == NULL) {
+        ret = PyUnicode_AsUTF8String(scalar);
+        if (ret == NULL) {
+            PyErr_SetString(
+                    PyExc_TypeError,
+                    "Can only store UTF8 text in a StringDType array.");
+            return NULL;
+        }
+    }
+    else if (scalar_type == StringNA_Type) {
+        ret = scalar;
+        Py_INCREF(ret);
+    }
+    // store np.nan as NA
+    else if (scalar_type == &PyFloat_Type) {
+        double scalar_val = PyFloat_AsDouble(scalar);
+        if ((scalar_val == -1.0) && PyErr_Occurred()) {
+            return NULL;
+        }
+        if (npy_isnan(scalar_val)) {
+            ret = NA_OBJ;
+            Py_INCREF(ret);
+        }
+        else {
             PyErr_SetString(
                     PyExc_TypeError,
                     "Can only store UTF8 text in a StringDType array.");
@@ -99,7 +122,7 @@ get_value(PyObject *scalar)
                         "Can only store String text in a StringDType array.");
         return NULL;
     }
-    return ret_bytes;
+    return ret;
 }
 
 // Take a python object `obj` and insert it into the array of dtype `descr` at
@@ -109,58 +132,74 @@ stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
                     char **dataptr)
 {
     PyObject *val_obj = get_value(obj);
+
     if (val_obj == NULL) {
         return -1;
     }
 
-    char *val = NULL;
-    Py_ssize_t length = 0;
-    if (PyBytes_AsStringAndSize(val_obj, &val, &length) == -1) {
-        return -1;
-    }
+    ss *sdata = (ss *)dataptr;
 
     // free if dataptr holds preexisting string data,
     // ssfree does a NULL check
-    ssfree((ss *)dataptr);
+    ssfree(sdata);
 
-    // copies contents of val into item_val->buf
-    int res = ssnewlen(val, length, (ss *)dataptr);
+    // RichCompareBool short-circuits to a pointer comparison fast-path
+    // so no need to do pointer comparison first
+    int eq_res = PyObject_RichCompareBool(val_obj, NA_OBJ, Py_EQ);
 
-    // val_obj must stay alive until here to ensure *val* doesn't get
-    // deallocated
+    if (eq_res < 0) {
+        goto error;
+    }
+
+    if (eq_res == 1) {
+        sdata = NULL;
+    }
+    else {
+        char *val = NULL;
+        Py_ssize_t length = 0;
+        if (PyBytes_AsStringAndSize(val_obj, &val, &length) == -1) {
+            goto error;
+        }
+
+        // copies contents of val into item_val->buf
+        int res = ssnewlen(val, length, sdata);
+
+        if (res == -1) {
+            PyErr_NoMemory();
+            goto error;
+        }
+        else if (res == -2) {
+            // this should never happen
+            assert(0);
+            goto error;
+        }
+    }
+
     Py_DECREF(val_obj);
-
-    if (res == -1) {
-        PyErr_NoMemory();
-        return -1;
-    }
-    else if (res == -2) {
-        // this should never happen
-        assert(0);
-    }
-
     return 0;
+
+error:
+    Py_DECREF(val_obj);
+    return -1;
 }
 
 static PyObject *
 stringdtype_getitem(StringDTypeObject *NPY_UNUSED(descr), char **dataptr)
 {
-    char *data;
-    size_t len;
+    PyObject *val_obj = NULL;
+    ss *sdata = (ss *)dataptr;
 
-    if (*dataptr == NULL) {
-        data = "\0";
-        len = 0;
+    if (ss_isnull(sdata)) {
+        Py_INCREF(NA_OBJ);
+        val_obj = NA_OBJ;
     }
     else {
-        data = ((ss *)dataptr)->buf;
-        len = ((ss *)dataptr)->len;
-    }
-
-    PyObject *val_obj = PyUnicode_FromStringAndSize(data, len);
-
-    if (val_obj == NULL) {
-        return NULL;
+        char *data = sdata->buf;
+        size_t len = sdata->len;
+        val_obj = PyUnicode_FromStringAndSize(data, len);
+        if (val_obj == NULL) {
+            return NULL;
+        }
     }
 
     /*
@@ -190,10 +229,22 @@ nonzero(void *data, void *NPY_UNUSED(arr))
 int
 compare(void *a, void *b, void *NPY_UNUSED(arr))
 {
-    ss *ss_a = NULL;
-    ss *ss_b = NULL;
-    load_string(a, &ss_a);
-    load_string(b, &ss_b);
+    ss *ss_a = (ss *)a;
+    ss *ss_b = (ss *)b;
+    int a_is_null = ss_isnull(ss_a);
+    int b_is_null = ss_isnull(ss_b);
+    if (a_is_null || b_is_null) {
+        // numpy sorts NaNs to the end of the array
+        // pandas sorts NAs to the end as well
+        // so we follow that behavior here
+        if (!b_is_null) {
+            return 1;
+        }
+        else if (!a_is_null) {
+            return -1;
+        }
+        return 0;
+    }
     return strcmp(ss_a->buf, ss_b->buf);
 }
 
@@ -265,6 +316,21 @@ stringdtype_get_clear_loop(void *NPY_UNUSED(traverse_context),
     return 0;
 }
 
+static int
+stringdtype_fill_zero_value(PyArrayObject *arr)
+{
+    char *buf = PyArray_DATA(arr);
+    npy_intp sz = PyArray_SIZE(arr);
+    int elsize = PyArray_DESCR(arr)->elsize;
+
+    for (npy_intp i = 0; i < sz; i++) {
+        if (ssnewlen("", 0, (ss *)(buf + i * elsize)) < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_common_instance, &common_instance},
         {NPY_DT_common_dtype, &common_dtype},
@@ -278,6 +344,7 @@ static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_PyArray_ArrFuncs_argmax, &argmax},
         {NPY_DT_PyArray_ArrFuncs_argmin, &argmin},
         {NPY_DT_get_clear_loop, &stringdtype_get_clear_loop},
+        {NPY_DT_fill_zero_value, &stringdtype_fill_zero_value},
         {0, NULL}};
 
 static PyObject *
@@ -439,5 +506,14 @@ init_string_dtype(void)
         free(casts[i]);
     }
 
+    return 0;
+}
+
+int
+init_string_na_object(PyObject *mod)
+{
+    NA_OBJ = PyObject_GetAttrString(mod, "NA");
+    StringNA_Type = Py_TYPE(NA_OBJ);
+    Py_INCREF(StringNA_Type);
     return 0;
 }

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -152,8 +152,8 @@ stringdtype_setitem(StringDTypeObject *NPY_UNUSED(descr), PyObject *obj,
     }
 
     if (eq_res == 1) {
-        // NULL is the representation of NA in the array buffer
-        sdata = NULL;
+        // do nothing, ssfree already NULLed the struct ssdata points to
+        // so it already contains a NA value
     }
     else {
         char *val = NULL;

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -12,6 +12,7 @@
 #include "numpy/arrayobject.h"
 #include "numpy/experimental_dtype_api.h"
 #include "numpy/ndarraytypes.h"
+#include "numpy/npy_math.h"
 
 typedef struct {
     PyArray_Descr base;
@@ -28,6 +29,10 @@ init_string_dtype(void);
 
 int
 compare(void *, void *, void *);
+
+int
+init_string_na_object(PyObject *mod);
+
 
 // from dtypemeta.h, not public in numpy
 #define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -91,7 +91,7 @@ PyInit__main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(9) < 0) {
+    if (import_experimental_dtype_api(10) < 0) {
         return NULL;
     }
 
@@ -114,6 +114,10 @@ PyInit__main(void)
     }
 
     if (init_string_dtype() < 0) {
+        goto error;
+    }
+
+    if (init_string_na_object(mod) < 0) {
         goto error;
     }
 

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -1,10 +1,17 @@
 #include "static_string.h"
 
+static ss EMPTY = {0, ""};
+
 int
 ssnewlen(const char *init, size_t len, ss *to_init)
 {
-    if ((to_init->buf != NULL) || (to_init->len != 0)) {
+    if ((to_init == NULL) || (to_init->buf != NULL) || (to_init->len != 0)) {
         return -2;
+    }
+
+    if (len == 0) {
+        to_init->len = 0;
+        to_init->buf = EMPTY.buf;
     }
 
     // one extra byte for null terminator
@@ -31,7 +38,9 @@ void
 ssfree(ss *str)
 {
     if (str->buf != NULL) {
-        free(str->buf);
+        if (str->buf != EMPTY.buf) {
+            free(str->buf);
+        }
         str->buf = NULL;
     }
     str->len = 0;
@@ -40,7 +49,14 @@ ssfree(ss *str)
 int
 ssdup(ss *in, ss *out)
 {
-    return ssnewlen(in->buf, in->len, out);
+    if (ss_isnull(in)) {
+        out->len = 0;
+        out->buf = NULL;
+        return 0;
+    }
+    else {
+        return ssnewlen(in->buf, in->len, out);
+    }
 }
 
 int
@@ -62,16 +78,11 @@ ssnewemptylen(size_t num_bytes, ss *out)
     return 0;
 }
 
-static ss EMPTY = {0, "\0"};
-
-void
-load_string(char *data, ss **out)
+int
+ss_isnull(ss *in)
 {
-    ss *ss_d = (ss *)data;
-    if (ss_d->len == 0) {
-        *out = &EMPTY;
+    if (in->len == 0 && in->buf == NULL) {
+        return 1;
     }
-    else {
-        *out = ss_d;
-    }
+    return 0;
 }

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -34,13 +34,9 @@ ssdup(ss *in, ss *out);
 int
 ssnewemptylen(size_t num_bytes, ss *out);
 
-// Interpret the contents of buffer *data* as an ss struct and set *out* to
-// that struct. If *data* is NULL, set *out* to point to a statically
-// allocated, empty SS struct. Since this function may set *out* to point to
-// statically allocated data, do not ever free memory owned by an output of
-// this function. That means this function is most useful for read-only
-// applications.
-void
-load_string(char *data, ss **out);
+// Determine if *in* corresponds to a NULL ss struct (e.g. len is zero and buf
+// is NULL. Returns 1 if this is the case and zero otherwise. Cannot fail.
+int
+ss_isnull(ss *in);
 
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -7,7 +7,7 @@ import tempfile
 import numpy as np
 import pytest
 
-from stringdtype import StringDType, StringScalar, _memory_usage
+from stringdtype import NA, StringDType, StringScalar, _memory_usage
 
 
 @pytest.fixture
@@ -121,9 +121,9 @@ def test_equality_promotion(string_list):
 
 
 def test_isnan(string_list):
-    sarr = np.array(string_list, dtype=StringDType())
+    sarr = np.array(string_list + [NA], dtype=StringDType())
     np.testing.assert_array_equal(
-        np.isnan(sarr), np.zeros_like(sarr, dtype=np.bool_)
+        np.isnan(sarr), np.array([0] * len(string_list) + [1], dtype=np.bool_)
     )
 
 
@@ -212,12 +212,11 @@ def test_creation_functions():
         np.zeros(3, dtype=StringDType()), ["", "", ""]
     )
 
-    np.testing.assert_array_equal(
-        np.empty(3, dtype=StringDType()), ["", "", ""]
-    )
+    assert np.zeros(3, dtype=StringDType())[0] == ""
 
-    # make sure getitem works too
-    assert np.empty(3, dtype=StringDType())[0] == ""
+    assert np.all(np.isnan(np.empty(3, dtype=StringDType())))
+
+    assert np.empty(3, dtype=StringDType())[0] is NA
 
 
 def test_is_numeric():
@@ -244,14 +243,14 @@ def test_argmax(strings):
 @pytest.mark.parametrize(
     "arrfunc,expected",
     [
-        [np.sort, np.empty(10, dtype=StringDType())],
+        [np.sort, np.zeros(10, dtype=StringDType())],
         [np.nonzero, (np.array([], dtype=np.int64),)],
         [np.argmax, 0],
         [np.argmin, 0],
     ],
 )
-def test_arrfuncs_empty(arrfunc, expected):
-    arr = np.empty(10, dtype=StringDType())
+def test_arrfuncs_zeros(arrfunc, expected):
+    arr = np.zeros(10, dtype=StringDType())
     result = arrfunc(arr)
     np.testing.assert_array_equal(result, expected, strict=True)
 
@@ -316,3 +315,14 @@ def test_ufunc_add(string_list, other_strings):
         np.add(arr1, arr2),
         np.array([a + b for a, b in zip(arr1, arr2)], dtype=StringDType()),
     )
+
+
+@pytest.mark.parametrize("na_val", [float("nan"), np.nan, NA])
+def test_create_with_na(na_val):
+    string_list = ["hello", na_val, "world"]
+    arr = np.array(string_list, dtype=StringDType())
+    assert (
+        repr(arr)
+        == "array(['hello', stringdtype.NA, 'world'], dtype=StringDType())"
+    )
+    assert arr[1] == NA and arr[1] is NA

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -185,12 +185,24 @@ def test_pickle(string_list):
 )
 def test_sort(strings):
     """Test that sorting matches python's internal sorting."""
-    arr = np.array(strings, dtype=StringDType())
-    arr_sorted = np.array(sorted(strings), dtype=StringDType())
 
-    np.random.default_rng().shuffle(arr)
-    arr.sort()
-    np.testing.assert_array_equal(arr, arr_sorted)
+    def test_sort(strings, arr_sorted):
+        arr = np.array(strings, dtype=StringDType())
+        np.random.default_rng().shuffle(arr)
+        arr.sort()
+        assert np.array_equal(arr, arr_sorted, equal_nan=True)
+
+    arr_sorted = np.array(sorted(strings), dtype=StringDType())
+    test_sort(strings, arr_sorted)
+
+    # make sure NAs get sorted to the end of the array
+    strings.insert(0, NA)
+    strings.insert(2, NA)
+    # can't use append because doing that with NA converts
+    # the result to object dtype
+    arr_sorted = np.array(arr_sorted.tolist() + [NA, NA], dtype=StringDType())
+
+    test_sort(strings, arr_sorted)
 
 
 @pytest.mark.parametrize(

--- a/unytdtype/meson.build
+++ b/unytdtype/meson.build
@@ -35,7 +35,8 @@ py.install_sources(
     'unytdtype/__init__.py',
     'unytdtype/scalar.py'
   ],
-  subdir: 'unytdtype'
+  subdir: 'unytdtype',
+  pure: false
 )
 
 py.extension_module(

--- a/unytdtype/unytdtype/src/unytdtype_main.c
+++ b/unytdtype/unytdtype/src/unytdtype_main.c
@@ -21,7 +21,7 @@ PyInit__unytdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(9) < 0) {
+    if (import_experimental_dtype_api(10) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
Currently we have two ways of representing an empty string:

```C
ss empty = {0, ""}
ss null = {0, NULL}
```

This PR repurposes the second struct layout to represent missing data, using a new `stringdtype.NA` type. This eliminated the need for the `load_string` helper but necessitated a new `ss_isnull` helper that I've added to the static string header.

Before this PR `np.zeros` depended on the second layout being translated to an empty string by `getitem`, so repurposing that layout to mean missing data means we need additional API surface in the dtype API to specify custom zero-filling logic. See https://github.com/numpy/numpy/pull/23591 for that, this PR depends on that numpy PR being merged first.

To avoid churning through a large number of 1-byte mallocs whenever `np.zeros` is called, I now return a static empty string if a user requests an empty string, and added a check in `ssfree` to avoid freeing that static string.

I've decided it makes sense for `np.empty` to return an array filled with missing data. I could also add additional API in numpy to customize empty-filling if we decide it makes sense to do something else.

I still need to make `NAType` behave more like `NaN` or pandas' `NA` in case someone accesses the NA scalar and uses it in operations with other strings, but I'm punting on that for a future PR.