### PR TITLE
Make it possible for users to use a custom NA value

### DIFF
--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -22,11 +22,8 @@ string_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
                                      npy_intp *view_offset)
 {
     if (given_descrs[1] == NULL) {
-        StringDTypeObject *new = new_stringdtype_instance();
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = (PyArray_Descr *)new;
+        Py_INCREF(given_descrs[0]);
+        loop_descrs[1] = given_descrs[0];
     }
     else {
         Py_INCREF(given_descrs[1]);
@@ -89,7 +86,7 @@ unicode_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
                                       npy_intp *NPY_UNUSED(view_offset))
 {
     if (given_descrs[1] == NULL) {
-        StringDTypeObject *new = new_stringdtype_instance();
+        StringDTypeObject *new = new_stringdtype_instance(NA_OBJ);
         if (new == NULL) {
             return (NPY_CASTING)-1;
         }

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -16,13 +16,15 @@
 
 typedef struct {
     PyArray_Descr base;
+    PyObject *na_object;
 } StringDTypeObject;
 
 extern PyArray_DTypeMeta StringDType;
 extern PyTypeObject *StringScalar_Type;
+extern PyObject *NA_OBJ;
 
 StringDTypeObject *
-new_stringdtype_instance(void);
+new_stringdtype_instance(PyObject *na_object);
 
 int
 init_string_dtype(void);
@@ -32,7 +34,6 @@ compare(void *, void *, void *);
 
 int
 init_string_na_object(PyObject *mod);
-
 
 // from dtypemeta.h, not public in numpy
 #define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -113,11 +113,11 @@ PyInit__main(void)
         goto error;
     }
 
-    if (init_string_dtype() < 0) {
+    if (init_string_na_object(mod) < 0) {
         goto error;
     }
 
-    if (init_string_na_object(mod) < 0) {
+    if (init_string_dtype() < 0) {
         goto error;
     }
 

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -13,6 +13,39 @@
 #include "string.h"
 #include "umath.h"
 
+static NPY_CASTING
+binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+                           PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
+                           PyArray_Descr *given_descrs[],
+                           PyArray_Descr *loop_descrs[],
+                           npy_intp *NPY_UNUSED(view_offset))
+{
+    PyObject *na_obj1 = ((StringDTypeObject *)given_descrs[0])->na_object;
+    PyObject *na_obj2 = ((StringDTypeObject *)given_descrs[1])->na_object;
+
+    int eq_res = PyObject_RichCompareBool(na_obj1, na_obj2, Py_EQ);
+
+    if (eq_res < 0) {
+        return (NPY_CASTING)-1;
+    }
+
+    if (eq_res != 1) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Can only do binary operations with identical "
+                        "StringDType instances.");
+        return (NPY_CASTING)-1;
+    }
+
+    Py_INCREF(given_descrs[0]);
+    loop_descrs[0] = given_descrs[0];
+    Py_INCREF(given_descrs[1]);
+    loop_descrs[1] = given_descrs[1];
+    Py_INCREF(given_descrs[1]);
+    loop_descrs[2] = given_descrs[1];
+
+    return NPY_NO_CASTING;
+}
+
 static int
 add_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
                  char *const data[], npy_intp const dimensions[],
@@ -27,9 +60,9 @@ add_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
     npy_intp out_stride = strides[2];
 
     ss *s1 = NULL, *s2 = NULL, *os = NULL;
-    int newlen = 0;
 
     while (N--) {
+        int newlen = 0;
         s1 = (ss *)in1;
         s2 = (ss *)in2;
         os = (ss *)out;
@@ -312,16 +345,10 @@ init_ufunc(PyObject *numpy, const char *ufunc_name, PyArray_DTypeMeta **dtypes,
             .dtypes = dtypes,
     };
 
-    if (resolve_func == NULL) {
-        PyType_Slot slots[] = {{NPY_METH_strided_loop, loop_func}, {0, NULL}};
-        spec.slots = slots;
-    }
-    else {
-        PyType_Slot slots[] = {{NPY_METH_resolve_descriptors, resolve_func},
-                               {NPY_METH_strided_loop, loop_func},
-                               {0, NULL}};
-        spec.slots = slots;
-    }
+    PyType_Slot slots[] = {{NPY_METH_resolve_descriptors, resolve_func},
+                           {NPY_METH_strided_loop, loop_func},
+                           {0, NULL}};
+    spec.slots = slots;
 
     if (PyUFunc_AddLoopFromSpec(ufunc, &spec) < 0) {
         Py_DECREF(ufunc);
@@ -406,21 +433,22 @@ init_ufuncs(void)
 
     PyArray_DTypeMeta *minmax_dtypes[] = {&StringDType, &StringDType,
                                           &StringDType};
-    if (init_ufunc(numpy, "maximum", minmax_dtypes, NULL,
-                   &maximum_strided_loop, "string_maximum", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
+    if (init_ufunc(numpy, "maximum", minmax_dtypes,
+                   &binary_resolve_descriptors, &maximum_strided_loop,
+                   "string_maximum", 2, 1, NPY_NO_CASTING, 0) < 0) {
         goto error;
     }
-    if (init_ufunc(numpy, "minimum", minmax_dtypes, NULL,
-                   &minimum_strided_loop, "string_minimum", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
+    if (init_ufunc(numpy, "minimum", minmax_dtypes,
+                   &binary_resolve_descriptors, &minimum_strided_loop,
+                   "string_minimum", 2, 1, NPY_NO_CASTING, 0) < 0) {
         goto error;
     }
 
     PyArray_DTypeMeta *add_types[] = {&StringDType, &StringDType,
                                       &StringDType};
-    if (init_ufunc(numpy, "add", add_types, NULL, &add_strided_loop,
-                   "string_add", 2, 1, NPY_NO_CASTING, 0) < 0) {
+    if (init_ufunc(numpy, "add", add_types, &binary_resolve_descriptors,
+                   &add_strided_loop, "string_add", 2, 1, NPY_NO_CASTING,
+                   0) < 0) {
         goto error;
     }
 

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -338,3 +338,14 @@ def test_create_with_na(na_val):
         == "array(['hello', stringdtype.NA, 'world'], dtype=StringDType())"
     )
     assert arr[1] == NA and arr[1] is NA
+
+
+def test_custom_na():
+    dtype = StringDType(na_object=None)
+    string_list = ["hello", None, "world"]
+    arr = np.array(string_list, dtype=dtype)
+    assert (
+        repr(arr)
+        == "array(['hello', None, 'world'], dtype=StringDType(na_object=None))"
+    )
+    assert arr[1] is None


### PR DESCRIPTION
This makes it possible to create a `StringDType` instance with a missing data sentinel supplied by the user. I'm going to use this in my pandas fork so that the dtype handles inserting `pd.NA` for the pandas extension dtype I'm writing.

I'm putting this in now because it works, however there's a design issue in that `discover_descriptor_from_pyobject` can't possibly work correctly. It *would* work if I could specialize at the level of the dtype class, since that function is supplied a reference to the  the dtype class. That approach would also let me avoid making the dtype parametric, which would simplify things a bit.

I'm going to try implementing this again, storing the na object in the DType class's `tp_dict`. If that turns out to have worse performance we can move forward with this approach.