### PR TITLE
WIP: convert MetadataDType to a heap type

### DIFF
--- a/metadatadtype/metadatadtype/src/dtype.h
+++ b/metadatadtype/metadatadtype/src/dtype.h
@@ -13,23 +13,31 @@
 #include "numpy/experimental_dtype_api.h"
 #include "numpy/ndarraytypes.h"
 
+// module state
+typedef struct {
+    PyArray_DTypeMeta *MetadataDType;
+    PyTypeObject *MetadataScalar_Type;
+} metadatadtype_state;
+
+// MetadataDType objects
+
+// Instance state
 typedef struct {
     PyArray_Descr base;
     PyObject *metadata;
 } MetadataDTypeObject;
 
-extern PyArray_DTypeMeta MetadataDType;
-extern PyTypeObject *MetadataScalar_Type;
-
 MetadataDTypeObject *
-new_metadatadtype_instance(PyObject *metadata);
+new_metadatadtype_instance(metadatadtype_state *state, PyObject *metadata);
 
 int
-init_metadata_dtype(void);
+init_metadata_dtype(PyObject *m);
 
 PyArray_Descr *
 common_instance(MetadataDTypeObject *dtype1,
                 MetadataDTypeObject *NPY_UNUSED(dtype2));
+
+extern struct PyModuleDef metadatadtype_module;
 
 // from numpy's dtypemeta.h, not publicly available
 #define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -8,56 +8,84 @@
 #include "dtype.h"
 #include "umath.h"
 
-static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT,
-        .m_name = "metadatadtype_main",
-        .m_size = -1,
-};
-
-/* Module initialization function */
-PyMODINIT_FUNC
-PyInit__metadatadtype_main(void)
+static int
+metadatadtypemodule_modexec(PyObject *m)
 {
+    metadatadtype_state *state = PyModule_GetState(m);
+
     if (_import_array() < 0) {
-        return NULL;
+        return -1;
     }
     if (import_experimental_dtype_api(11) < 0) {
-        return NULL;
-    }
-
-    PyObject *m = PyModule_Create(&moduledef);
-    if (m == NULL) {
-        return NULL;
+        return -1;
     }
 
     PyObject *mod = PyImport_ImportModule("metadatadtype");
     if (mod == NULL) {
         goto error;
     }
-    MetadataScalar_Type =
+    state->MetadataScalar_Type =
             (PyTypeObject *)PyObject_GetAttrString(mod, "MetadataScalar");
     Py_DECREF(mod);
 
-    if (MetadataScalar_Type == NULL) {
+    if (state->MetadataScalar_Type == NULL) {
         goto error;
     }
 
-    if (init_metadata_dtype() < 0) {
+    if (init_metadata_dtype(m) < 0) {
         goto error;
     }
 
-    if (PyModule_AddObject(m, "MetadataDType", (PyObject *)&MetadataDType) <
-        0) {
+    if (PyModule_AddType(m, (PyTypeObject *)state->MetadataDType) < 0) {
         goto error;
     }
 
-    if (init_ufuncs() < 0) {
+    if (init_ufuncs(state->MetadataDType) < 0) {
         goto error;
     }
 
-    return m;
+    return 0;
 
 error:
     Py_DECREF(m);
-    return NULL;
+    return -1;
+}
+
+static int
+metadatadtypemodule_traverse(PyObject *module, visitproc visit, void *arg)
+{
+    metadatadtype_state *state = PyModule_GetState(module);
+    Py_VISIT(state->MetadataDType);
+    Py_VISIT(state->MetadataScalar_Type);
+    return 0;
+}
+
+static int
+metadatadtypemodule_clear(PyObject *module)
+{
+    metadatadtype_state *state = PyModule_GetState(module);
+    Py_CLEAR(state->MetadataDType);
+    Py_CLEAR(state->MetadataScalar_Type);
+    return 0;
+}
+
+static PyModuleDef_Slot metadatadtypemodule_slots[] = {
+        {Py_mod_exec, metadatadtypemodule_modexec},
+        {0, NULL},
+};
+
+struct PyModuleDef metadatadtype_module = {
+        PyModuleDef_HEAD_INIT,
+        .m_name = "_metadatadtype_main",
+        .m_size = sizeof(metadatadtype_state),
+        .m_slots = metadatadtypemodule_slots,
+        .m_traverse = metadatadtypemodule_traverse,
+        .m_clear = metadatadtypemodule_clear,
+};
+
+/* Module initialization function */
+PyMODINIT_FUNC
+PyInit__metadatadtype_main(void)
+{
+    return PyModuleDef_Init(&metadatadtype_module);
 }

--- a/metadatadtype/metadatadtype/src/umath.c
+++ b/metadatadtype/metadatadtype/src/umath.c
@@ -1,15 +1,8 @@
 #include <Python.h>
 
-#define PY_ARRAY_UNIQUE_SYMBOL metadatadtype_ARRAY_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#define NO_IMPORT_ARRAY
-#include "numpy/arrayobject.h"
-#include "numpy/experimental_dtype_api.h"
-#include "numpy/ndarraytypes.h"
-#include "numpy/ufuncobject.h"
+#include "umath.h"
 
 #include "dtype.h"
-#include "umath.h"
 
 static int
 translate_given_descrs(int nin, int nout,
@@ -103,10 +96,10 @@ add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta **dtypes,
 }
 
 int
-init_ufuncs(void)
+init_ufuncs(PyArray_DTypeMeta *MetadataDType)
 {
-    PyArray_DTypeMeta *binary_orig_dtypes[3] = {&MetadataDType, &MetadataDType,
-                                                &MetadataDType};
+    PyArray_DTypeMeta *binary_orig_dtypes[3] = {MetadataDType, MetadataDType,
+                                                MetadataDType};
     PyArray_DTypeMeta *binary_wrapped_dtypes[3] = {
             &PyArray_DoubleDType, &PyArray_DoubleDType, &PyArray_DoubleDType};
     if (add_wrapping_loop("multiply", binary_orig_dtypes,
@@ -114,7 +107,7 @@ init_ufuncs(void)
         goto error;
     }
 
-    PyArray_DTypeMeta *unary_boolean_dtypes[2] = {&MetadataDType,
+    PyArray_DTypeMeta *unary_boolean_dtypes[2] = {MetadataDType,
                                                   &PyArray_BoolDType};
     PyArray_DTypeMeta *unary_boolean_wrapped_dtypes[2] = {&PyArray_DoubleDType,
                                                           &PyArray_BoolDType};

--- a/metadatadtype/metadatadtype/src/umath.h
+++ b/metadatadtype/metadatadtype/src/umath.h
@@ -1,7 +1,15 @@
 #ifndef _NPY_UFUNC_H
 #define _NPY_UFUNC_H
 
+#define PY_ARRAY_UNIQUE_SYMBOL metadatadtype_ARRAY_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NO_IMPORT_ARRAY
+#include "numpy/arrayobject.h"
+#include "numpy/experimental_dtype_api.h"
+#include "numpy/ndarraytypes.h"
+#include "numpy/ufuncobject.h"
+
 int
-init_ufuncs(void);
+init_ufuncs(PyArray_DTypeMeta *MetadataDType);
 
 #endif /*_NPY_UFUNC_H */


### PR DESCRIPTION
This doesn't work but I wanted to issue the PR just to save the work in case it becomes more useful in the future. I suspect this likely won't be viable until Python 3.12 is widely available.