### PR TITLE
Add a statically defined PandasStringDType

### DIFF
--- a/stringdtype/stringdtype/__init__.py
+++ b/stringdtype/stringdtype/__init__.py
@@ -3,8 +3,8 @@
 """
 
 from .missing import NA  # isort: skip
-from .scalar import StringScalar  # isort: skip
-from ._main import StringDType, _memory_usage
+from .scalar import StringScalar, PandasStringScalar  # isort: skip
+from ._main import PandasStringDType, StringDType, _memory_usage
 
 __all__ = [
     "NA",
@@ -12,3 +12,9 @@ __all__ = [
     "StringScalar",
     "_memory_usage",
 ]
+
+# this happens when pandas isn't importable
+if StringDType is PandasStringDType:
+    del PandasStringDType
+else:
+    __all__.extend("PandasStringDType")

--- a/stringdtype/stringdtype/scalar.py
+++ b/stringdtype/stringdtype/scalar.py
@@ -1,5 +1,9 @@
-"""A scalar type needed by the dtype machinery."""
+"""Scalar types needed by the dtype machinery."""
 
 
 class StringScalar(str):
+    pass
+
+
+class PandasStringScalar(str):
     pass

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -86,7 +86,7 @@ unicode_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
                                       npy_intp *NPY_UNUSED(view_offset))
 {
     if (given_descrs[1] == NULL) {
-        StringDTypeObject *new = new_stringdtype_instance(NA_OBJ);
+        StringDTypeObject *new = new_stringdtype_instance();
         if (new == NULL) {
             return (NPY_CASTING)-1;
         }

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -80,17 +80,18 @@ static char *s2s_name = "cast_StringDType_to_StringDType";
 
 static NPY_CASTING
 unicode_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                      PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
+                                      PyArray_DTypeMeta *dtypes[2],
                                       PyArray_Descr *given_descrs[2],
                                       PyArray_Descr *loop_descrs[2],
                                       npy_intp *NPY_UNUSED(view_offset))
 {
     if (given_descrs[1] == NULL) {
-        StringDTypeObject *new = new_stringdtype_instance();
+        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
+                (PyTypeObject *)dtypes[1]);
         if (new == NULL) {
             return (NPY_CASTING)-1;
         }
-        loop_descrs[1] = (PyArray_Descr *)new;
+        loop_descrs[1] = new;
     }
     else {
         Py_INCREF(given_descrs[1]);

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -16,15 +16,14 @@
 
 typedef struct {
     PyArray_Descr base;
-    PyObject *na_object;
 } StringDTypeObject;
 
 extern PyArray_DTypeMeta StringDType;
 extern PyTypeObject *StringScalar_Type;
 extern PyObject *NA_OBJ;
 
-StringDTypeObject *
-new_stringdtype_instance(void);
+PyObject *
+new_stringdtype_instance(PyTypeObject *cls);
 
 int
 init_string_dtype(void);

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -24,7 +24,7 @@ extern PyTypeObject *StringScalar_Type;
 extern PyObject *NA_OBJ;
 
 StringDTypeObject *
-new_stringdtype_instance(PyObject *na_object);
+new_stringdtype_instance(void);
 
 int
 init_string_dtype(void);

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -19,7 +19,9 @@ typedef struct {
 } StringDTypeObject;
 
 extern PyArray_DTypeMeta StringDType;
+extern PyArray_DTypeMeta PandasStringDType;
 extern PyTypeObject *StringScalar_Type;
+extern PyTypeObject *PandasStringScalar_Type;
 extern PyObject *NA_OBJ;
 
 PyObject *

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -18,8 +18,13 @@ typedef struct {
     PyArray_Descr base;
 } StringDTypeObject;
 
-extern PyArray_DTypeMeta StringDType;
-extern PyArray_DTypeMeta PandasStringDType;
+typedef struct {
+    PyArray_DTypeMeta base;
+    PyObject *na_object;
+} StringDType_type;
+
+extern StringDType_type StringDType;
+extern StringDType_type PandasStringDType;
 extern PyTypeObject *StringScalar_Type;
 extern PyTypeObject *PandasStringScalar_Type;
 extern PyObject *NA_OBJ;

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -107,9 +107,17 @@ PyInit__main(void)
 
     StringScalar_Type =
             (PyTypeObject *)PyObject_GetAttrString(mod, "StringScalar");
-    Py_DECREF(mod);
 
     if (StringScalar_Type == NULL) {
+        goto error;
+    }
+
+    PandasStringScalar_Type =
+            (PyTypeObject *)PyObject_GetAttrString(mod, "PandasStringScalar");
+
+    Py_DECREF(mod);
+
+    if (PandasStringScalar_Type == NULL) {
         goto error;
     }
 
@@ -124,6 +132,13 @@ PyInit__main(void)
     Py_INCREF((PyObject *)&StringDType);
     if (PyModule_AddObject(m, "StringDType", (PyObject *)&StringDType) < 0) {
         Py_DECREF((PyObject *)&StringDType);
+        goto error;
+    }
+
+    Py_INCREF((PyObject *)&PandasStringDType);
+    if (PyModule_AddObject(m, "PandasStringDType",
+                           (PyObject *)&PandasStringDType) < 0) {
+        Py_DECREF((PyObject *)&PandasStringDType);
         goto error;
     }
 

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -23,7 +23,7 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
     PyArray_Descr *descr = PyArray_DESCR(arr);
     PyArray_DTypeMeta *dtype = NPY_DTYPE(descr);
 
-    if (dtype != &StringDType) {
+    if (dtype != (PyArray_DTypeMeta *)&StringDType) {
         PyErr_SetString(PyExc_TypeError,
                         "can only be called with a StringDType array");
         return NULL;

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -15,21 +15,19 @@
 
 static NPY_CASTING
 binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-                           PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
+                           PyArray_DTypeMeta *dtypes[],
                            PyArray_Descr *given_descrs[],
                            PyArray_Descr *loop_descrs[],
                            npy_intp *NPY_UNUSED(view_offset))
 {
-    PyObject *na_obj1 = ((StringDTypeObject *)given_descrs[0])->na_object;
-    PyObject *na_obj2 = ((StringDTypeObject *)given_descrs[1])->na_object;
+    // technically incorrect to cast to StringDType if we have a
+    // PandasStringDType but they have the same layout so this should be fine.
+    PyObject *na_obj1 = PyDict_GetItemString(
+            ((PyTypeObject *)dtypes[0])->tp_dict, "na_object");
+    PyObject *na_obj2 = PyDict_GetItemString(
+            ((PyTypeObject *)dtypes[1])->tp_dict, "na_object");
 
-    int eq_res = PyObject_RichCompareBool(na_obj1, na_obj2, Py_EQ);
-
-    if (eq_res < 0) {
-        return (NPY_CASTING)-1;
-    }
-
-    if (eq_res != 1) {
+    if (na_obj1 != na_obj2) {
         PyErr_SetString(PyExc_TypeError,
                         "Can only do binary operations with identical "
                         "StringDType instances.");

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -338,3 +338,15 @@ def test_create_with_na(na_val):
         == "array(['hello', stringdtype.NA, 'world'], dtype=StringDType())"
     )
     assert arr[1] == NA and arr[1] is NA
+
+
+def test_pandas_string_dtype():
+    pandas = pytest.importorskip("pandas")
+    from stringdtype import PandasStringDType
+
+    assert PandasStringDType.na_object is pandas.NA
+
+    string_list = ["hello", np.nan, "world"]
+    arr = np.array(string_list, dtype=PandasStringDType())
+
+    assert arr[1] is pandas.NA

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -338,14 +338,3 @@ def test_create_with_na(na_val):
         == "array(['hello', stringdtype.NA, 'world'], dtype=StringDType())"
     )
     assert arr[1] == NA and arr[1] is NA
-
-
-def test_custom_na():
-    dtype = StringDType(na_object=None)
-    string_list = ["hello", None, "world"]
-    arr = np.array(string_list, dtype=dtype)
-    assert (
-        repr(arr)
-        == "array(['hello', None, 'world'], dtype=StringDType(na_object=None))"
-    )
-    assert arr[1] is None


### PR DESCRIPTION
Late last week I discovered that in some cases casting from object dtype to stringdtype doesn't work if stringdtype is parametric (see [here](https://github.com/numpy/numpy/blob/cc0abd768575d7f9e862de0b4912af27f6e9690d/numpy/core/src/multiarray/convert_datatype.c#L3757-L3764)). In particular this makes it difficult to use the ufunc promotion machinery to add an override for the `equal` and `not_equal` ufuncs for object to string comparisons. This is a big issue working with pandas because object string arrays are widely used inside pandas.

I only added the parametric flag as a stopgap because I couldn't figure out how to convert stringdtype into a subtype of `PyArray_DTypeMeta` with an additional field to hold the NA object, or even a way to dynamically define `PyArray_DTypeMeta` instances at all. I'm still not sure how to do that without adding restrictions I'd like to avoid like requiring Python 3.12 or newer and also needing to make changes in the dtype API machinery in numpy to support dynamically defined dtype classes.

In this PR I've taken the compromise approach of *statically* defining two different string dtype classes. One has a generic `NA` implementation, the other uses `Pandas.NA` explicitly. This leads to some copy/pasting when setting up the dtype classes, but it buys us not needing to have a parametric dtype and dealing with the restrictions parametric dtypes have in numpy.

I don't know if subtyping `PyArray_DtypeMeta` will lead to other issues in the future. I could just store the `na_object` field in the `tp_dict`, but then I'd add the overhead of a `PyDict_GetItemString` call every time we need a reference to the NA object in C. I'd love it if @seberg could chime in about that or any other issues.