### PR TITLE
Add casts between StringDType and PandasStringDType

### DIFF
--- a/stringdtype/pyproject.toml
+++ b/stringdtype/pyproject.toml
@@ -35,6 +35,6 @@ per-file-ignores = {"__init__.py" = ["F401"]}
 
 [tool.meson-python.args]
 dist = []
-setup = ["-Ddebug=true", "-Doptimization=0"]
+setup = ["-Dbuildtype=debug"]
 compile = []
 install = []

--- a/stringdtype/stringdtype/src/casts.h
+++ b/stringdtype/stringdtype/src/casts.h
@@ -11,7 +11,8 @@
 #include "numpy/ndarraytypes.h"
 
 PyArrayMethod_Spec **
-get_casts(void);
+get_casts(PyArray_DTypeMeta *this_dtype, PyArray_DTypeMeta *other_dtype,
+          int pandas_available);
 
 size_t
 utf8_char_to_ucs4_code(unsigned char *, Py_UCS4 *);

--- a/stringdtype/stringdtype/src/casts.h
+++ b/stringdtype/stringdtype/src/casts.h
@@ -11,8 +11,7 @@
 #include "numpy/ndarraytypes.h"
 
 PyArrayMethod_Spec **
-get_casts(PyArray_DTypeMeta *this_dtype, PyArray_DTypeMeta *other_dtype,
-          int pandas_available);
+get_casts(PyArray_DTypeMeta *this_dtype, PyArray_DTypeMeta *other_dtype);
 
 size_t
 utf8_char_to_ucs4_code(unsigned char *, Py_UCS4 *);

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -533,9 +533,8 @@ init_string_dtype(void)
         PANDAS_AVAILABLE = 1;
     }
 
-    PyArrayMethod_Spec **StringDType_casts = get_casts(
-            (PyArray_DTypeMeta *)&StringDType,
-            (PyArray_DTypeMeta *)&PandasStringDType, PANDAS_AVAILABLE);
+    PyArrayMethod_Spec **StringDType_casts =
+            get_casts((PyArray_DTypeMeta *)&StringDType, NULL);
 
     PyArrayDTypeMeta_Spec StringDType_DTypeSpec = {
             .typeobj = StringScalar_Type,
@@ -556,10 +555,6 @@ init_string_dtype(void)
     if (PyType_Ready((PyTypeObject *)&StringDType) < 0) {
         return -1;
     }
-
-    // Partially initialize PandasStringDType so cast setup succeeds
-    ((PyObject *)&PandasStringDType)->ob_type = &PyArrayDTypeMeta_Type;
-    ((PyTypeObject *)&PandasStringDType)->tp_base = &PyArrayDescr_Type;
 
     if (PyArrayInitDTypeMeta_FromSpec((PyArray_DTypeMeta *)&StringDType,
                                       &StringDType_DTypeSpec) < 0) {
@@ -585,7 +580,7 @@ init_string_dtype(void)
     if (PANDAS_AVAILABLE) {
         PyArrayMethod_Spec **PandasStringDType_casts =
                 get_casts((PyArray_DTypeMeta *)&PandasStringDType,
-                          (PyArray_DTypeMeta *)&StringDType, PANDAS_AVAILABLE);
+                          (PyArray_DTypeMeta *)&StringDType);
 
         PyArrayDTypeMeta_Spec PandasStringDType_DTypeSpec = {
                 .typeobj = PandasStringScalar_Type,
@@ -601,6 +596,8 @@ init_string_dtype(void)
             return -1;
         }
 
+        ((PyObject *)&PandasStringDType)->ob_type = &PyArrayDTypeMeta_Type;
+        ((PyTypeObject *)&PandasStringDType)->tp_base = &PyArrayDescr_Type;
         ((PyTypeObject *)&PandasStringDType)->tp_dict = PyDict_New();
         // C attribute for fast access
         Py_INCREF(pandas_na_obj);


### PR DESCRIPTION
This refactors the cast setup to be a bit more generic and adds casts between `StringDType` and `PandasStringDType`. Since the binary representation is the same for both dtypes, I can reuse the string to string cast. There's also a small change to the meson setup to silence a warning from the latest version of meson.