### PR TITLE
Fix comparisons with object arrays

### DIFF
--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -449,6 +449,124 @@ static PyType_Slot s2b_slots[] = {
 
 static char *s2b_name = "cast_StringDType_to_Bool";
 
+// object to string
+
+typedef struct {
+    NpyAuxData base;
+    PyArray_Descr *descr;
+    int move_references;
+} _object_to_string_auxdata;
+
+static void
+_object_to_string_auxdata_free(NpyAuxData *auxdata)
+{
+    _object_to_string_auxdata *data = (_object_to_string_auxdata *)auxdata;
+    Py_DECREF(data->descr);
+    PyMem_Free(data);
+}
+
+static NpyAuxData *
+_object_to_string_auxdata_clone(NpyAuxData *data)
+{
+    _object_to_string_auxdata *res = PyMem_Malloc(sizeof(*res));
+    if (res == NULL) {
+        return NULL;
+    }
+    memcpy(res, data, sizeof(*res));
+    Py_INCREF(res->descr);
+    return (NpyAuxData *)res;
+}
+
+static int
+object_to_string_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                              char *const *args, const npy_intp *dimensions,
+                              const npy_intp *strides, NpyAuxData *auxdata)
+{
+    npy_intp N = dimensions[0];
+    char *src = args[0], *dst = args[1];
+    npy_intp src_stride = strides[0], dst_stride = strides[1];
+    _object_to_string_auxdata *data = (_object_to_string_auxdata *)auxdata;
+
+    PyObject *src_ref;
+
+    while (N > 0) {
+        memcpy(&src_ref, src, sizeof(src_ref));
+        if (stringdtype_setitem((StringDTypeObject *)(data->descr),
+                                src_ref ? src_ref : Py_None,
+                                (void *)dst) < 0) {
+            return -1;
+        }
+
+        if (data->move_references && src_ref != NULL) {
+            Py_DECREF(src_ref);
+            memset(src, 0, sizeof(src_ref));
+        }
+
+        N--;
+        dst += dst_stride;
+        src += src_stride;
+    }
+    return 0;
+}
+
+NPY_NO_EXPORT int
+object_to_string_get_loop(PyArrayMethod_Context *context,
+                          int NPY_UNUSED(aligned), int move_references,
+                          const npy_intp *NPY_UNUSED(strides),
+                          PyArrayMethod_StridedLoop **out_loop,
+                          NpyAuxData **out_transferdata,
+                          NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    *flags = NPY_METH_REQUIRES_PYAPI;
+
+    /* NOTE: auxdata is only really necessary to flag `move_references` */
+    _object_to_string_auxdata *data = PyMem_Malloc(sizeof(*data));
+    if (data == NULL) {
+        return -1;
+    }
+    data->base.free = &_object_to_string_auxdata_free;
+    data->base.clone = &_object_to_string_auxdata_clone;
+
+    Py_INCREF(context->descriptors[1]);
+    data->descr = context->descriptors[1];
+    data->move_references = move_references;
+    *out_transferdata = (NpyAuxData *)data;
+    *out_loop = &object_to_string_strided_loop;
+    return 0;
+}
+
+static NPY_CASTING
+object_to_string_resolve_descriptors(PyArrayMethodObject *NPY_UNUSED(self),
+                                     PyArray_DTypeMeta *dtypes[2],
+                                     PyArray_Descr *given_descrs[2],
+                                     PyArray_Descr *loop_descrs[2],
+                                     npy_intp *NPY_UNUSED(view_offset))
+{
+    if (given_descrs[1] == NULL) {
+        loop_descrs[1] = (PyArray_Descr *)new_stringdtype_instance(
+                (PyTypeObject *)dtypes[1]);
+        if (loop_descrs[1] == NULL) {
+            return -1;
+        }
+    }
+    else {
+        Py_INCREF(given_descrs[1]);
+        loop_descrs[1] = given_descrs[1];
+    }
+
+    Py_INCREF(given_descrs[0]);
+    loop_descrs[0] = given_descrs[0];
+
+    return NPY_SAFE_CASTING;
+}
+
+static PyType_Slot o2s_slots[] = {
+        {NPY_METH_resolve_descriptors, &object_to_string_resolve_descriptors},
+        {_NPY_METH_get_loop, &object_to_string_get_loop},
+        {0, NULL}};
+
+static char *o2s_name = "cast_object_to_StringDType";
+
 PyArrayMethod_Spec *
 get_cast_spec(const char *name, NPY_CASTING casting,
               NPY_ARRAYMETHOD_FLAGS flags, PyArray_DTypeMeta **dtypes,
@@ -501,10 +619,10 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
 
     int is_pandas = (this == (PyArray_DTypeMeta *)&PandasStringDType);
 
-    int num_casts = 5;
+    int num_casts = 6;
 
     if (is_pandas) {
-        num_casts = 7;
+        num_casts = 8;
 
         PyArray_DTypeMeta **t2o_dtypes = get_dtypes(this, other);
 
@@ -537,6 +655,12 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
             s2b_name, NPY_UNSAFE_CASTING, NPY_METH_NO_FLOATINGPOINT_ERRORS,
             s2b_dtypes, s2b_slots);
 
+    PyArray_DTypeMeta **o2s_dtypes = get_dtypes(&PyArray_ObjectDType, this);
+
+    PyArrayMethod_Spec *ObjectToStringCastSpec =
+            get_cast_spec(o2s_name, NPY_SAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+                          o2s_dtypes, o2s_slots);
+
     PyArrayMethod_Spec **casts = NULL;
 
     casts = malloc(num_casts * sizeof(PyArrayMethod_Spec *));
@@ -545,13 +669,14 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
     casts[1] = UnicodeToStringCastSpec;
     casts[2] = StringToUnicodeCastSpec;
     casts[3] = StringToBoolCastSpec;
+    casts[4] = ObjectToStringCastSpec;
     if (is_pandas) {
-        casts[4] = ThisToOtherCastSpec;
-        casts[5] = OtherToThisCastSpec;
-        casts[6] = NULL;
+        casts[5] = ThisToOtherCastSpec;
+        casts[6] = OtherToThisCastSpec;
+        casts[7] = NULL;
     }
     else {
-        casts[4] = NULL;
+        casts[5] = NULL;
     }
 
     return casts;

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -130,7 +130,7 @@ string_discover_descriptor_from_pyobject(PyTypeObject *cls, PyObject *obj)
 
 // Take a python object `obj` and insert it into the array of dtype `descr` at
 // the position given by dataptr.
-static int
+int
 stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
 {
     // borrow reference

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -42,6 +42,9 @@ compare(void *, void *, void *);
 int
 init_string_na_object(PyObject *mod);
 
+int
+stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr);
+
 // from dtypemeta.h, not public in numpy
 #define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))
 

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -203,6 +203,163 @@ string_not_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
     return 0;
 }
 
+static int
+string_greater_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                            char *const data[], npy_intp const dimensions[],
+                            npy_intp const strides[],
+                            NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp N = dimensions[0];
+    char *in1 = data[0];
+    char *in2 = data[1];
+    npy_bool *out = (npy_bool *)data[2];
+    npy_intp in1_stride = strides[0];
+    npy_intp in2_stride = strides[1];
+    npy_intp out_stride = strides[2];
+
+    ss *s1 = NULL, *s2 = NULL;
+
+    while (N--) {
+        s1 = (ss *)in1;
+        s2 = (ss *)in2;
+        if (ss_isnull(s1) || ss_isnull(s2)) {
+            // s1 or s2 is NA
+            *out = (npy_bool)0;
+        }
+        else if (s1->len == s2->len &&
+                 strncmp(s1->buf, s2->buf, s1->len) > 0) {
+            *out = (npy_bool)0;
+        }
+        else {
+            *out = (npy_bool)1;
+        }
+
+        in1 += in1_stride;
+        in2 += in2_stride;
+        out += out_stride;
+    }
+
+    return 0;
+}
+
+static int
+string_greater_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                                  char *const data[],
+                                  npy_intp const dimensions[],
+                                  npy_intp const strides[],
+                                  NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp N = dimensions[0];
+    char *in1 = data[0];
+    char *in2 = data[1];
+    npy_bool *out = (npy_bool *)data[2];
+    npy_intp in1_stride = strides[0];
+    npy_intp in2_stride = strides[1];
+    npy_intp out_stride = strides[2];
+
+    ss *s1 = NULL, *s2 = NULL;
+
+    while (N--) {
+        s1 = (ss *)in1;
+        s2 = (ss *)in2;
+        if (ss_isnull(s1) || ss_isnull(s2)) {
+            // s1 or s2 is NA
+            *out = (npy_bool)0;
+        }
+        else if (s1->len == s2->len &&
+                 strncmp(s1->buf, s2->buf, s1->len) >= 0) {
+            *out = (npy_bool)0;
+        }
+        else {
+            *out = (npy_bool)1;
+        }
+
+        in1 += in1_stride;
+        in2 += in2_stride;
+        out += out_stride;
+    }
+
+    return 0;
+}
+
+static int
+string_less_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                         char *const data[], npy_intp const dimensions[],
+                         npy_intp const strides[],
+                         NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp N = dimensions[0];
+    char *in1 = data[0];
+    char *in2 = data[1];
+    npy_bool *out = (npy_bool *)data[2];
+    npy_intp in1_stride = strides[0];
+    npy_intp in2_stride = strides[1];
+    npy_intp out_stride = strides[2];
+
+    ss *s1 = NULL, *s2 = NULL;
+
+    while (N--) {
+        s1 = (ss *)in1;
+        s2 = (ss *)in2;
+        if (ss_isnull(s1) || ss_isnull(s2)) {
+            // s1 or s2 is NA
+            *out = (npy_bool)0;
+        }
+        else if (s1->len == s2->len &&
+                 strncmp(s1->buf, s2->buf, s1->len) < 0) {
+            *out = (npy_bool)0;
+        }
+        else {
+            *out = (npy_bool)1;
+        }
+
+        in1 += in1_stride;
+        in2 += in2_stride;
+        out += out_stride;
+    }
+
+    return 0;
+}
+
+static int
+string_less_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                               char *const data[], npy_intp const dimensions[],
+                               npy_intp const strides[],
+                               NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp N = dimensions[0];
+    char *in1 = data[0];
+    char *in2 = data[1];
+    npy_bool *out = (npy_bool *)data[2];
+    npy_intp in1_stride = strides[0];
+    npy_intp in2_stride = strides[1];
+    npy_intp out_stride = strides[2];
+
+    ss *s1 = NULL, *s2 = NULL;
+
+    while (N--) {
+        s1 = (ss *)in1;
+        s2 = (ss *)in2;
+        if (ss_isnull(s1) || ss_isnull(s2)) {
+            // s1 or s2 is NA
+            *out = (npy_bool)0;
+        }
+        else if (s1->len == s2->len &&
+                 strncmp(s1->buf, s2->buf, s1->len) <= 0) {
+            *out = (npy_bool)0;
+        }
+        else {
+            *out = (npy_bool)1;
+        }
+
+        in1 += in1_stride;
+        in2 += in2_stride;
+        out += out_stride;
+    }
+
+    return 0;
+}
+
 static NPY_CASTING
 string_comparison_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
@@ -330,7 +487,8 @@ string_ufunc_promoter(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtypes[],
 }
 
 static int
-pandas_string_ufunc_promoter(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtypes[],
+pandas_string_ufunc_promoter(PyUFuncObject *ufunc,
+                             PyArray_DTypeMeta *op_dtypes[],
                              PyArray_DTypeMeta *signature[],
                              PyArray_DTypeMeta *new_op_dtypes[])
 {
@@ -400,16 +558,15 @@ add_promoter(PyObject *numpy, const char *ufunc_name,
     }
 
     PyObject *promoter_capsule = NULL;
-    
+
     if (is_pandas == 0) {
         promoter_capsule = PyCapsule_New((void *)&string_ufunc_promoter,
-                                          "numpy._ufunc_promoter", NULL);
+                                         "numpy._ufunc_promoter", NULL);
     }
     else {
         promoter_capsule = PyCapsule_New((void *)&pandas_string_ufunc_promoter,
                                          "numpy._ufunc_promoter", NULL);
     }
-            
 
     if (promoter_capsule == NULL) {
         Py_DECREF(ufunc);
@@ -439,171 +596,134 @@ init_ufuncs(void)
         return -1;
     }
 
-    PyArray_DTypeMeta *comparison_dtypes[] = {(PyArray_DTypeMeta *)&StringDType,
-                                              (PyArray_DTypeMeta *)&StringDType,
-                                              &PyArray_BoolDType};
+    StringDType_type **dtype_classes = NULL;
+    int num_dtypes;
 
-    if (init_ufunc(numpy, "equal", comparison_dtypes,
-                   &string_comparison_resolve_descriptors,
-                   &string_equal_strided_loop, "string_equal", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
+    if (PANDAS_AVAILABLE) {
+        dtype_classes = malloc(sizeof(StringDType_type *) * 2);
+        dtype_classes[0] = &StringDType;
+        dtype_classes[1] = &PandasStringDType;
+        num_dtypes = 2;
+    }
+    else {
+        dtype_classes = malloc(sizeof(StringDType_type *) * 1);
+        dtype_classes[0] = &StringDType;
+        num_dtypes = 1;
     }
 
-    if (init_ufunc(numpy, "not_equal", comparison_dtypes,
-                   &string_comparison_resolve_descriptors,
-                   &string_not_equal_strided_loop, "string_not_equal", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
+    for (int di = 0; di < num_dtypes; di++) {
+        PyArray_DTypeMeta *comparison_dtypes[] = {
+                (PyArray_DTypeMeta *)dtype_classes[di],
+                (PyArray_DTypeMeta *)dtype_classes[di], &PyArray_BoolDType};
 
-    char *ufunc_names[2] = {"equal", "not_equal"};
-
-    for (int i = 0; i < 2; i++) {
-        if (add_promoter(numpy, ufunc_names[i], (PyArray_DTypeMeta *)&StringDType,
-                         &PyArray_UnicodeDType, &PyArray_BoolDType, 0) < 0) {
+        if (init_ufunc(numpy, "equal", comparison_dtypes,
+                       &string_comparison_resolve_descriptors,
+                       &string_equal_strided_loop, "string_equal", 2, 1,
+                       NPY_NO_CASTING, 0) < 0) {
             goto error;
         }
 
-        if (add_promoter(numpy, ufunc_names[i], &PyArray_UnicodeDType,
-                         (PyArray_DTypeMeta *)&StringDType, &PyArray_BoolDType, 0) < 0) {
+        if (init_ufunc(numpy, "not_equal", comparison_dtypes,
+                       &string_comparison_resolve_descriptors,
+                       &string_not_equal_strided_loop, "string_not_equal", 2,
+                       1, NPY_NO_CASTING, 0) < 0) {
             goto error;
         }
 
-        if (add_promoter(numpy, ufunc_names[i], &PyArray_ObjectDType,
-                         (PyArray_DTypeMeta *)&StringDType, &PyArray_BoolDType, 0) < 0) {
+        if (init_ufunc(numpy, "greater", comparison_dtypes,
+                       &string_comparison_resolve_descriptors,
+                       &string_greater_strided_loop, "string_greater", 2, 1,
+                       NPY_NO_CASTING, 0) < 0) {
             goto error;
         }
 
-        if (add_promoter(numpy, ufunc_names[i], (PyArray_DTypeMeta *)&StringDType,
-                         &PyArray_ObjectDType, &PyArray_BoolDType, 0) < 0) {
+        if (init_ufunc(numpy, "greater_equal", comparison_dtypes,
+                       &string_comparison_resolve_descriptors,
+                       &string_greater_equal_strided_loop,
+                       "string_greater_equal", 2, 1, NPY_NO_CASTING, 0) < 0) {
+            goto error;
+        }
+
+        if (init_ufunc(numpy, "less", comparison_dtypes,
+                       &string_comparison_resolve_descriptors,
+                       &string_less_strided_loop, "string_less", 2, 1,
+                       NPY_NO_CASTING, 0) < 0) {
+            goto error;
+        }
+
+        if (init_ufunc(numpy, "less_equal", comparison_dtypes,
+                       &string_comparison_resolve_descriptors,
+                       &string_less_equal_strided_loop, "string_less_equal", 2,
+                       1, NPY_NO_CASTING, 0) < 0) {
+            goto error;
+        }
+
+        static char *ufunc_names[6] = {"equal",   "not_equal",
+                                       "greater", "greater_equal",
+                                       "less",    "less_equal"};
+
+        for (int i = 0; i < 6; i++) {
+            if (add_promoter(numpy, ufunc_names[i],
+                             (PyArray_DTypeMeta *)dtype_classes[di],
+                             &PyArray_UnicodeDType, &PyArray_BoolDType,
+                             0) < 0) {
+                goto error;
+            }
+
+            if (add_promoter(numpy, ufunc_names[i], &PyArray_UnicodeDType,
+                             (PyArray_DTypeMeta *)dtype_classes[di],
+                             &PyArray_BoolDType, 0) < 0) {
+                goto error;
+            }
+
+            if (add_promoter(numpy, ufunc_names[i], &PyArray_ObjectDType,
+                             (PyArray_DTypeMeta *)dtype_classes[di],
+                             &PyArray_BoolDType, 0) < 0) {
+                goto error;
+            }
+
+            if (add_promoter(numpy, ufunc_names[i],
+                             (PyArray_DTypeMeta *)dtype_classes[di],
+                             &PyArray_ObjectDType, &PyArray_BoolDType,
+                             0) < 0) {
+                goto error;
+            }
+        }
+
+        PyArray_DTypeMeta *isnan_dtypes[] = {
+                (PyArray_DTypeMeta *)dtype_classes[di], &PyArray_BoolDType};
+
+        if (init_ufunc(numpy, "isnan", isnan_dtypes,
+                       &string_isnan_resolve_descriptors,
+                       &string_isnan_strided_loop, "string_isnan", 1, 1,
+                       NPY_NO_CASTING, 0) < 0) {
+            goto error;
+        }
+
+        PyArray_DTypeMeta *binary_dtypes[] = {
+                (PyArray_DTypeMeta *)dtype_classes[di],
+                (PyArray_DTypeMeta *)dtype_classes[di],
+                (PyArray_DTypeMeta *)dtype_classes[di],
+        };
+
+        if (init_ufunc(numpy, "maximum", binary_dtypes, NULL,
+                       &maximum_strided_loop, "string_maximum", 2, 1,
+                       NPY_NO_CASTING, 0) < 0) {
+            goto error;
+        }
+
+        if (init_ufunc(numpy, "minimum", binary_dtypes, NULL,
+                       &minimum_strided_loop, "string_minimum", 2, 1,
+                       NPY_NO_CASTING, 0) < 0) {
+            goto error;
+        }
+
+        if (init_ufunc(numpy, "add", binary_dtypes, NULL, &add_strided_loop,
+                       "string_add", 2, 1, NPY_NO_CASTING, 0) < 0) {
             goto error;
         }
     }
 
-    PyArray_DTypeMeta *isnan_dtypes[] = {(PyArray_DTypeMeta *)&StringDType,
-                                         &PyArray_BoolDType};
-
-    if (init_ufunc(numpy, "isnan", isnan_dtypes,
-                   &string_isnan_resolve_descriptors,
-                   &string_isnan_strided_loop, "string_isnan", 1, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    PyArray_DTypeMeta *minmax_dtypes[] = {
-            (PyArray_DTypeMeta *)&StringDType,
-            (PyArray_DTypeMeta *)&StringDType,
-            (PyArray_DTypeMeta *)&StringDType,
-    };
-
-    if (init_ufunc(numpy, "maximum", minmax_dtypes, NULL,
-                   &maximum_strided_loop, "string_maximum", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-    if (init_ufunc(numpy, "minimum", minmax_dtypes, NULL,
-                   &minimum_strided_loop, "string_minimum", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    PyArray_DTypeMeta *add_dtypes[] = {
-            (PyArray_DTypeMeta *)&StringDType,
-            (PyArray_DTypeMeta *)&StringDType,
-            (PyArray_DTypeMeta *)&StringDType,
-    };
-
-    if (init_ufunc(numpy, "add", add_dtypes, NULL, &add_strided_loop,
-                   "string_add", 2, 1, NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    if (!PANDAS_AVAILABLE) {
-        goto finish;
-    }
-
-    PyArray_DTypeMeta *p_comparison_dtypes[] =
-            {(PyArray_DTypeMeta *)&PandasStringDType,
-             (PyArray_DTypeMeta *)&PandasStringDType,
-             &PyArray_BoolDType};
-
-    if (init_ufunc(numpy, "equal", p_comparison_dtypes,
-                   &string_comparison_resolve_descriptors,
-                   &string_equal_strided_loop, "string_equal", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    if (init_ufunc(numpy, "not_equal", p_comparison_dtypes,
-                   &string_comparison_resolve_descriptors,
-                   &string_not_equal_strided_loop, "string_not_equal", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    for (int i = 0; i < 2; i++) {
-        if (add_promoter(numpy, ufunc_names[i], (PyArray_DTypeMeta *)&PandasStringDType,
-                         &PyArray_UnicodeDType, &PyArray_BoolDType, 1) < 0) {
-            goto error;
-        }
-
-        if (add_promoter(numpy, ufunc_names[i], &PyArray_UnicodeDType,
-                         (PyArray_DTypeMeta *)&PandasStringDType, &PyArray_BoolDType, 1) < 0) {
-            goto error;
-        }
-
-        if (add_promoter(numpy, ufunc_names[i], &PyArray_ObjectDType,
-                         (PyArray_DTypeMeta *)&PandasStringDType, &PyArray_BoolDType, 1) < 0) {
-            goto error;
-        }
-
-        if (add_promoter(numpy, ufunc_names[i], (PyArray_DTypeMeta *)&PandasStringDType,
-                         &PyArray_ObjectDType, &PyArray_BoolDType, 1) < 0) {
-            goto error;
-        }
-    }
-
-    PyArray_DTypeMeta *p_isnan_dtypes[] = {
-            (PyArray_DTypeMeta *)&PandasStringDType, &PyArray_BoolDType};
-
-    if (init_ufunc(numpy, "isnan", p_isnan_dtypes,
-                   &string_isnan_resolve_descriptors,
-                   &string_isnan_strided_loop, "string_isnan", 1, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    PyArray_DTypeMeta *p_minmax_dtypes[] = {
-            (PyArray_DTypeMeta *)&PandasStringDType,
-            (PyArray_DTypeMeta *)&PandasStringDType,
-            (PyArray_DTypeMeta *)&PandasStringDType,
-    };
-
-    if (init_ufunc(numpy, "maximum", p_minmax_dtypes, NULL,
-                   &maximum_strided_loop, "string_maximum", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    if (init_ufunc(numpy, "minimum", p_minmax_dtypes, NULL,
-                   &minimum_strided_loop, "string_minimum", 2, 1,
-                   NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-    PyArray_DTypeMeta *p_add_dtypes[] = {
-            (PyArray_DTypeMeta *)&PandasStringDType,
-            (PyArray_DTypeMeta *)&PandasStringDType,
-            (PyArray_DTypeMeta *)&PandasStringDType,
-    };
-
-    if (init_ufunc(numpy, "add", p_add_dtypes, NULL, &add_strided_loop,
-                   "string_add", 2, 1, NPY_NO_CASTING, 0) < 0) {
-        goto error;
-    }
-
-finish:
     Py_DECREF(numpy);
     return 0;
 

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -226,8 +226,7 @@ string_greater_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
             // s1 or s2 is NA
             *out = (npy_bool)0;
         }
-        else if (s1->len == s2->len &&
-                 strncmp(s1->buf, s2->buf, s1->len) > 0) {
+        else if (strcmp(s1->buf, s2->buf) > 0) {
             *out = (npy_bool)1;
         }
         else {
@@ -266,8 +265,7 @@ string_greater_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
             // s1 or s2 is NA
             *out = (npy_bool)0;
         }
-        else if (s1->len == s2->len &&
-                 strncmp(s1->buf, s2->buf, s1->len) >= 0) {
+        else if (strcmp(s1->buf, s2->buf) >= 0) {
             *out = (npy_bool)1;
         }
         else {
@@ -305,8 +303,7 @@ string_less_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
             // s1 or s2 is NA
             *out = (npy_bool)0;
         }
-        else if (s1->len == s2->len &&
-                 strncmp(s1->buf, s2->buf, s1->len) < 0) {
+        else if (strcmp(s1->buf, s2->buf) < 0) {
             *out = (npy_bool)1;
         }
         else {
@@ -344,8 +341,7 @@ string_less_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
             // s1 or s2 is NA
             *out = (npy_bool)0;
         }
-        else if (s1->len == s2->len &&
-                 strncmp(s1->buf, s2->buf, s1->len) <= 0) {
+        else if (strcmp(s1->buf, s2->buf) <= 0) {
             *out = (npy_bool)1;
         }
         else {

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -228,10 +228,10 @@ string_greater_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
         }
         else if (s1->len == s2->len &&
                  strncmp(s1->buf, s2->buf, s1->len) > 0) {
-            *out = (npy_bool)0;
+            *out = (npy_bool)1;
         }
         else {
-            *out = (npy_bool)1;
+            *out = (npy_bool)0;
         }
 
         in1 += in1_stride;
@@ -268,10 +268,10 @@ string_greater_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
         }
         else if (s1->len == s2->len &&
                  strncmp(s1->buf, s2->buf, s1->len) >= 0) {
-            *out = (npy_bool)0;
+            *out = (npy_bool)1;
         }
         else {
-            *out = (npy_bool)1;
+            *out = (npy_bool)0;
         }
 
         in1 += in1_stride;
@@ -307,10 +307,10 @@ string_less_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
         }
         else if (s1->len == s2->len &&
                  strncmp(s1->buf, s2->buf, s1->len) < 0) {
-            *out = (npy_bool)0;
+            *out = (npy_bool)1;
         }
         else {
-            *out = (npy_bool)1;
+            *out = (npy_bool)0;
         }
 
         in1 += in1_stride;
@@ -346,10 +346,10 @@ string_less_equal_strided_loop(PyArrayMethod_Context *NPY_UNUSED(context),
         }
         else if (s1->len == s2->len &&
                  strncmp(s1->buf, s2->buf, s1->len) <= 0) {
-            *out = (npy_bool)0;
+            *out = (npy_bool)1;
         }
         else {
-            *out = (npy_bool)1;
+            *out = (npy_bool)0;
         }
 
         in1 += in1_stride;

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -39,7 +39,7 @@ def dtype(request):
 
 @pytest.fixture
 def scalar(dtype):
-    if dtype == StringDType():
+    if isinstance(dtype, StringDType):
         return StringScalar
     else:
         return PandasStringScalar

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -154,20 +154,34 @@ comparison_operators = [
 
 @pytest.mark.parametrize("op", comparison_operators)
 @pytest.mark.parametrize("o_dtype", [np.str_, object])
-def test_comparison(string_list, dtype, op, o_dtype):
+def test_comparisons(string_list, dtype, op, o_dtype):
     sarr = np.array(string_list, dtype=dtype)
     oarr = np.array(string_list, dtype=o_dtype)
 
     # test that comparison operators work
     res = op(sarr, sarr)
     ores = op(oarr, oarr)
-    # test that promotion on the operator works as well
+    # test that promotion works as well
     orres = op(sarr, oarr)
     olres = op(oarr, sarr)
 
     np.testing.assert_array_equal(res, ores)
     np.testing.assert_array_equal(res, orres)
     np.testing.assert_array_equal(res, olres)
+
+    # test we get the correct answer for unequal length strings
+    sarr2 = np.array([s + "2" for s in string_list], dtype=dtype)
+    oarr2 = np.array([s + "2" for s in string_list], dtype=o_dtype)
+
+    res = op(sarr, sarr2)
+    ores = op(oarr, oarr2)
+
+    np.testing.assert_array_equal(res, ores)
+
+    res = op(sarr2, sarr)
+    ores = op(oarr2, oarr)
+
+    np.testing.assert_array_equal(res, ores)
 
 
 def test_isnan(dtype, string_list):

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -142,15 +142,30 @@ def test_insert_scalar(dtype, scalar, string_list):
         )
 
 
+comparison_operators = [
+    np.equal,
+    np.not_equal,
+    np.greater,
+    np.greater_equal,
+    np.less,
+    np.less_equal,
+]
+
+
+@pytest.mark.parametrize("op", comparison_operators)
 @pytest.mark.parametrize("o_dtype", [np.str_, object])
-def test_equality_promotion(string_list, dtype, o_dtype):
+def test_comparison(string_list, dtype, op, o_dtype):
     sarr = np.array(string_list, dtype=dtype)
     oarr = np.array(string_list, dtype=o_dtype)
 
-    np.testing.assert_array_equal(sarr, oarr)
-    np.testing.assert_array_equal(oarr, sarr)
-    assert not np.any(sarr != oarr)
-    assert not np.any(oarr != sarr)
+    # test that comparison operators work
+    res = op(sarr, sarr)
+    # test that promotion on the operator works as well
+    orres = op(sarr, oarr)
+    olres = op(oarr, sarr)
+
+    np.testing.assert_array_equal(res, orres)
+    np.testing.assert_array_equal(res, olres)
 
 
 def test_isnan(dtype, string_list):

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -153,7 +153,7 @@ comparison_operators = [
 
 
 @pytest.mark.parametrize("op", comparison_operators)
-@pytest.mark.parametrize("o_dtype", [np.str_, object])
+@pytest.mark.parametrize("o_dtype", [np.str_, object, StringDType()])
 def test_comparisons(string_list, dtype, op, o_dtype):
     sarr = np.array(string_list, dtype=dtype)
     oarr = np.array(string_list, dtype=o_dtype)
@@ -175,13 +175,21 @@ def test_comparisons(string_list, dtype, op, o_dtype):
 
     res = op(sarr, sarr2)
     ores = op(oarr, oarr2)
+    olres = op(oarr, sarr2)
+    orres = op(sarr, oarr2)
 
     np.testing.assert_array_equal(res, ores)
+    np.testing.assert_array_equal(res, olres)
+    np.testing.assert_array_equal(res, orres)
 
     res = op(sarr2, sarr)
     ores = op(oarr2, oarr)
+    olres = op(oarr2, sarr)
+    orres = op(sarr2, oarr)
 
     np.testing.assert_array_equal(res, ores)
+    np.testing.assert_array_equal(res, olres)
+    np.testing.assert_array_equal(res, orres)
 
 
 def test_isnan(dtype, string_list):

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -160,10 +160,12 @@ def test_comparison(string_list, dtype, op, o_dtype):
 
     # test that comparison operators work
     res = op(sarr, sarr)
+    ores = op(oarr, oarr)
     # test that promotion on the operator works as well
     orres = op(sarr, oarr)
     olres = op(oarr, sarr)
 
+    np.testing.assert_array_equal(res, ores)
     np.testing.assert_array_equal(res, orres)
     np.testing.assert_array_equal(res, olres)
 

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -142,12 +142,15 @@ def test_insert_scalar(dtype, scalar, string_list):
         )
 
 
-def test_equality_promotion(dtype, string_list):
+@pytest.mark.parametrize("o_dtype", [np.str_, object])
+def test_equality_promotion(string_list, dtype, o_dtype):
     sarr = np.array(string_list, dtype=dtype)
-    uarr = np.array(string_list, dtype=np.str_)
+    oarr = np.array(string_list, dtype=o_dtype)
 
-    np.testing.assert_array_equal(sarr, uarr)
-    np.testing.assert_array_equal(uarr, sarr)
+    np.testing.assert_array_equal(sarr, oarr)
+    np.testing.assert_array_equal(oarr, sarr)
+    assert not np.any(sarr != oarr)
+    assert not np.any(oarr != sarr)
 
 
 def test_isnan(dtype, string_list):


### PR DESCRIPTION
Refactors the existing promoter into a function that can be called by the real promoter passed to Numpy, allowing us to parameterize the final dtypes that will go into a ufunc loop. The existing usages of promoters all get promoted to StringDType. I also added a new promoter that promotes all inputs to object, since there is a safe cast from string to object built in to NumPy. This fixes equality comparisons with object arrays.

While I was at it, I also added implementations for the `not_equal`, `less`, `less_equal`, and `greater` ufuncs. I could have chosen to make `umath.c` C++ or used some other templating system, but I'm fine with the limited amount of copy/paste in these ufunc loop implementations without adding the added complexity of building C++ code portably or figuring out how to integrate a custom template system. I think it's also possible to avoid the copy/paste with a complicated set of nested preprocessor macros, but that would make the code substantially harder to read.