### PR TITLE
Add round-trip casts between string and (u)int dtypes

### DIFF
--- a/asciidtype/asciidtype/src/asciidtype_main.c
+++ b/asciidtype/asciidtype/src/asciidtype_main.c
@@ -22,7 +22,7 @@ PyInit__asciidtype_main(void)
         return NULL;
     }
 
-    if (import_experimental_dtype_api(11) < 0) {
+    if (import_experimental_dtype_api(12) < 0) {
         return NULL;
     }
 

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -21,7 +21,7 @@ PyInit__metadatadtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(11) < 0) {
+    if (import_experimental_dtype_api(12) < 0) {
         return NULL;
     }
 

--- a/mpfdtype/mpfdtype/src/mpfdtype_main.c
+++ b/mpfdtype/mpfdtype/src/mpfdtype_main.c
@@ -22,7 +22,7 @@ PyInit__mpfdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(11) < 0) {
+    if (import_experimental_dtype_api(12) < 0) {
         return NULL;
     }
 

--- a/quaddtype/quaddtype/src/quaddtype_main.c
+++ b/quaddtype/quaddtype/src/quaddtype_main.c
@@ -23,7 +23,7 @@ PyInit__quaddtype_main(void)
         return NULL;
 
     // Fail to init if the experimental DType API version 5 isn't supported
-    if (import_experimental_dtype_api(11) < 0) {
+    if (import_experimental_dtype_api(12) < 0) {
         PyErr_SetString(PyExc_ImportError,
                         "Error encountered importing the experimental dtype API.");
         return NULL;

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -605,6 +605,32 @@ uint_to_string(unsigned long long in, char *out)
     return pylong_to_string(pylong_val, out);
 }
 
+static NPY_CASTING
+int_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
+                                  PyArray_DTypeMeta *dtypes[2],
+                                  PyArray_Descr *given_descrs[2],
+                                  PyArray_Descr *loop_descrs[2],
+                                  npy_intp *NPY_UNUSED(view_offset))
+{
+    if (given_descrs[1] == NULL) {
+        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
+                (PyTypeObject *)dtypes[1]);
+        if (new == NULL) {
+            return (NPY_CASTING)-1;
+        }
+        loop_descrs[1] = new;
+    }
+    else {
+        Py_INCREF(given_descrs[1]);
+        loop_descrs[1] = given_descrs[1];
+    }
+
+    Py_INCREF(given_descrs[0]);
+    loop_descrs[0] = given_descrs[0];
+
+    return NPY_UNSAFE_CASTING;
+}
+
 // string to int8
 
 static NPY_CASTING
@@ -668,32 +694,6 @@ static char *s2i8_name = "cast_StringDType_to_Int8";
 
 // int8 to string
 
-static NPY_CASTING
-int8_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                   PyArray_DTypeMeta *dtypes[2],
-                                   PyArray_Descr *given_descrs[2],
-                                   PyArray_Descr *loop_descrs[2],
-                                   npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 int8_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                npy_intp const dimensions[], npy_intp const strides[],
@@ -718,7 +718,7 @@ int8_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 }
 
 static PyType_Slot i82s_slots[] = {
-        {NPY_METH_resolve_descriptors, &int8_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &int8_to_string},
         {0, NULL}};
 
@@ -787,32 +787,6 @@ static char *s2i16_name = "cast_StringDType_to_Int16";
 
 // int16 to string
 
-static NPY_CASTING
-int16_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                    PyArray_DTypeMeta *dtypes[2],
-                                    PyArray_Descr *given_descrs[2],
-                                    PyArray_Descr *loop_descrs[2],
-                                    npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 int16_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                 npy_intp const dimensions[], npy_intp const strides[],
@@ -837,7 +811,7 @@ int16_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 }
 
 static PyType_Slot i162s_slots[] = {
-        {NPY_METH_resolve_descriptors, &int16_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &int16_to_string},
         {0, NULL}};
 
@@ -906,32 +880,6 @@ static char *s2i32_name = "cast_StringDType_to_Int32";
 
 // int32 to string
 
-static NPY_CASTING
-int32_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                    PyArray_DTypeMeta *dtypes[2],
-                                    PyArray_Descr *given_descrs[2],
-                                    PyArray_Descr *loop_descrs[2],
-                                    npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 int32_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                 npy_intp const dimensions[], npy_intp const strides[],
@@ -956,7 +904,7 @@ int32_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 }
 
 static PyType_Slot i322s_slots[] = {
-        {NPY_METH_resolve_descriptors, &int32_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &int32_to_string},
         {0, NULL}};
 
@@ -1025,32 +973,6 @@ static char *s2i64_name = "cast_StringDType_to_Int64";
 
 // int64 to string
 
-static NPY_CASTING
-int64_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                    PyArray_DTypeMeta *dtypes[2],
-                                    PyArray_Descr *given_descrs[2],
-                                    PyArray_Descr *loop_descrs[2],
-                                    npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 int64_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                 npy_intp const dimensions[], npy_intp const strides[],
@@ -1075,7 +997,7 @@ int64_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 }
 
 static PyType_Slot i642s_slots[] = {
-        {NPY_METH_resolve_descriptors, &int64_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &int64_to_string},
         {0, NULL}};
 
@@ -1144,32 +1066,6 @@ static char *s2ui8_name = "cast_StringDType_to_UInt8";
 
 // uint8 to string
 
-static NPY_CASTING
-uint8_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                    PyArray_DTypeMeta *dtypes[2],
-                                    PyArray_Descr *given_descrs[2],
-                                    PyArray_Descr *loop_descrs[2],
-                                    npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 uint8_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                 npy_intp const dimensions[], npy_intp const strides[],
@@ -1194,7 +1090,7 @@ uint8_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 }
 
 static PyType_Slot ui82s_slots[] = {
-        {NPY_METH_resolve_descriptors, &uint8_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &uint8_to_string},
         {0, NULL}};
 
@@ -1263,32 +1159,6 @@ static char *s2ui16_name = "cast_StringDType_to_UInt16";
 
 // uint16 to string
 
-static NPY_CASTING
-uint16_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                     PyArray_DTypeMeta *dtypes[2],
-                                     PyArray_Descr *given_descrs[2],
-                                     PyArray_Descr *loop_descrs[2],
-                                     npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 uint16_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
                  char *const data[], npy_intp const dimensions[],
@@ -1313,7 +1183,7 @@ uint16_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
 }
 
 static PyType_Slot ui162s_slots[] = {
-        {NPY_METH_resolve_descriptors, &uint16_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &uint16_to_string},
         {0, NULL}};
 
@@ -1382,32 +1252,6 @@ static char *s2ui32_name = "cast_StringDType_to_UInt32";
 
 // uint32 to string
 
-static NPY_CASTING
-uint32_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                     PyArray_DTypeMeta *dtypes[2],
-                                     PyArray_Descr *given_descrs[2],
-                                     PyArray_Descr *loop_descrs[2],
-                                     npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 uint32_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
                  char *const data[], npy_intp const dimensions[],
@@ -1432,7 +1276,7 @@ uint32_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
 }
 
 static PyType_Slot ui322s_slots[] = {
-        {NPY_METH_resolve_descriptors, &uint32_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &uint32_to_string},
         {0, NULL}};
 
@@ -1501,32 +1345,6 @@ static char *s2ui64_name = "cast_StringDType_to_UInt64";
 
 // uint64 to string
 
-static NPY_CASTING
-uint64_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
-                                     PyArray_DTypeMeta *dtypes[2],
-                                     PyArray_Descr *given_descrs[2],
-                                     PyArray_Descr *loop_descrs[2],
-                                     npy_intp *NPY_UNUSED(view_offset))
-{
-    if (given_descrs[1] == NULL) {
-        PyArray_Descr *new = (PyArray_Descr *)new_stringdtype_instance(
-                (PyTypeObject *)dtypes[1]);
-        if (new == NULL) {
-            return (NPY_CASTING)-1;
-        }
-        loop_descrs[1] = new;
-    }
-    else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
-    }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    return NPY_UNSAFE_CASTING;
-}
-
 static int
 uint64_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
                  char *const data[], npy_intp const dimensions[],
@@ -1551,7 +1369,7 @@ uint64_to_string(PyArrayMethod_Context *NPY_UNUSED(context),
 }
 
 static PyType_Slot ui642s_slots[] = {
-        {NPY_METH_resolve_descriptors, &uint64_to_string_resolve_descriptors},
+        {NPY_METH_resolve_descriptors, &int_to_string_resolve_descriptors},
         {NPY_METH_strided_loop, &uint64_to_string},
         {0, NULL}};
 

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -92,7 +92,7 @@ PyInit__main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(11) < 0) {
+    if (import_experimental_dtype_api(12) < 0) {
         return NULL;
     }
 

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -350,12 +350,28 @@ def test_arrfuncs_zeros(dtype, arrfunc, expected):
         [["", "world"], [False, True], True, False],
     ],
 )
-def test_bool_cast(dtype, strings, cast_answer, any_answer, all_answer):
+def test_cast_to_bool(dtype, strings, cast_answer, any_answer, all_answer):
     sarr = np.array(strings, dtype=dtype)
     np.testing.assert_array_equal(sarr.astype("bool"), cast_answer)
 
     assert np.any(sarr) == any_answer
     assert np.all(sarr) == all_answer
+
+
+@pytest.mark.parametrize(
+    ("strings", "cast_answer"),
+    [
+        [[True, True], ["True", "True"]],
+        [[False, False], ["False", "False"]],
+        [[True, False], ["True", "False"]],
+        [[False, True], ["False", "True"]],
+    ],
+)
+def test_cast_from_bool(dtype, strings, cast_answer):
+    barr = np.array(strings, dtype=bool)
+    np.testing.assert_array_equal(
+        barr.astype(dtype), np.array(cast_answer, dtype=dtype)
+    )
 
 
 def test_take(dtype, string_list):

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -374,6 +374,24 @@ def test_cast_from_bool(dtype, strings, cast_answer):
     )
 
 
+@pytest.mark.parametrize("bitsize", [8, 16, 32, 64])
+@pytest.mark.parametrize("signed", [True, False])
+def test_integer_casts(dtype, bitsize, signed):
+    idtype = f"int{bitsize}"
+    if signed:
+        inp = [-(2**p - 1) for p in reversed(range(bitsize - 1))]
+        inp += [2**p - 1 for p in range(1, bitsize - 1)]
+    else:
+        idtype = "u" + idtype
+        inp = [2**p - 1 for p in range(bitsize)]
+    ainp = np.array(inp, dtype=idtype)
+    np.testing.assert_array_equal(ainp, ainp.astype(dtype).astype(idtype))
+
+    oob = [str(2**bitsize), str(-(2**bitsize))]
+    with pytest.raises(OverflowError):
+        np.array(oob, dtype=dtype).astype(idtype)
+
+
 def test_take(dtype, string_list):
     sarr = np.array(string_list, dtype=dtype)
     out = np.empty(len(string_list), dtype=dtype)

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -387,6 +387,12 @@ def test_integer_casts(dtype, bitsize, signed):
     ainp = np.array(inp, dtype=idtype)
     np.testing.assert_array_equal(ainp, ainp.astype(dtype).astype(idtype))
 
+    with pytest.raises(TypeError):
+        ainp.astype(dtype, casting="safe")
+
+    with pytest.raises(TypeError):
+        ainp.astype(dtype).astype(idtype, casting="safe")
+
     oob = [str(2**bitsize), str(-(2**bitsize))]
     with pytest.raises(OverflowError):
         np.array(oob, dtype=dtype).astype(idtype)

--- a/unytdtype/unytdtype/src/unytdtype_main.c
+++ b/unytdtype/unytdtype/src/unytdtype_main.c
@@ -21,7 +21,7 @@ PyInit__unytdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(11) < 0) {
+    if (import_experimental_dtype_api(12) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
Making a PR to solicit feedback before I do this again for the float dtypes.

I could have done this without using the python C API but this approach seemed less finicky than dealing with serializing ints as strings in a portable way in C. FWIW, numpy currently does the equivalent cast for the unicode dtype by going through numpy scalars. In principle in the future we could drop the GIL requirement and do this in a more low-level way.

There's a lot of copy/paste here. It's very possible we've reached or are long past the point where writing this in C++ would be a good idea. I guess if this code is going to end up living in numpy eventually it's not problematic to add a build dependency on a C++ toolchain.