### PR TITLE
Add casts for integer dtypes that don't have a sized alias

### DIFF
--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -677,6 +677,38 @@ uint_to_string(unsigned long long in, char *out)
                                                                             \
     static char *shortname##2s_name = "cast_" #typename "_to_StringDType";
 
+#define INT_DTYPES_AND_CAST_SPEC(shortname, typename)                        \
+    PyArray_DTypeMeta **s2##shortname##_dtypes =                             \
+            get_dtypes(this, &PyArray_##typename##DType);                    \
+                                                                             \
+    PyArrayMethod_Spec *StringTo##typename##CastSpec =                       \
+            get_cast_spec(s2##shortname##_name, NPY_UNSAFE_CASTING,          \
+                          NPY_METH_REQUIRES_PYAPI, s2##shortname##_dtypes,   \
+                          s2##shortname##_slots);                            \
+                                                                             \
+    PyArray_DTypeMeta **shortname##2s_dtypes =                               \
+            get_dtypes(&PyArray_##typename##DType, this);                    \
+                                                                             \
+    PyArrayMethod_Spec *typename##ToStringCastSpec = get_cast_spec(          \
+            shortname##2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI, \
+            shortname##2s_dtypes, shortname##2s_slots);                      \
+                                                                             \
+    PyArray_DTypeMeta **s2u##shortname##_dtypes =                            \
+            get_dtypes(this, &PyArray_U##typename##DType);                   \
+                                                                             \
+    PyArrayMethod_Spec *StringToU##typename##CastSpec =                      \
+            get_cast_spec(s2u##shortname##_name, NPY_UNSAFE_CASTING,         \
+                          NPY_METH_REQUIRES_PYAPI, s2u##shortname##_dtypes,  \
+                          s2u##shortname##_slots);                           \
+                                                                             \
+    PyArray_DTypeMeta **u##shortname##2s_dtypes =                            \
+            get_dtypes(&PyArray_U##typename##DType, this);                   \
+                                                                             \
+    PyArrayMethod_Spec *U##typename##ToStringCastSpec =                      \
+            get_cast_spec(u##shortname##2s_name, NPY_UNSAFE_CASTING,         \
+                          NPY_METH_REQUIRES_PYAPI, u##shortname##2s_dtypes,  \
+                          u##shortname##2s_slots);
+
 STRING_TO_INT(int8, int, i8, NPY_INT8, lli, npy_longlong)
 INT_TO_STRING(int8, int, i8, long long)
 
@@ -844,211 +876,22 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
             b2s_name, NPY_SAFE_CASTING, NPY_METH_NO_FLOATINGPOINT_ERRORS,
             b2s_dtypes, b2s_slots);
 
-    PyArray_DTypeMeta **s2i8_dtypes = get_dtypes(this, &PyArray_Int8DType);
-
-    PyArrayMethod_Spec *StringToInt8CastSpec =
-            get_cast_spec(s2i8_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, s2i8_dtypes, s2i8_slots);
-
-    PyArray_DTypeMeta **i82s_dtypes = get_dtypes(&PyArray_Int8DType, this);
-
-    PyArrayMethod_Spec *Int8ToStringCastSpec =
-            get_cast_spec(i82s_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, i82s_dtypes, i82s_slots);
-
-    PyArray_DTypeMeta **s2ui8_dtypes = get_dtypes(this, &PyArray_UInt8DType);
-
-    PyArrayMethod_Spec *StringToUInt8CastSpec =
-            get_cast_spec(s2ui8_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, s2ui8_dtypes, s2ui8_slots);
-
-    PyArray_DTypeMeta **ui82s_dtypes = get_dtypes(&PyArray_UInt8DType, this);
-
-    PyArrayMethod_Spec *UInt8ToStringCastSpec =
-            get_cast_spec(ui82s_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, ui82s_dtypes, ui82s_slots);
-
-    PyArray_DTypeMeta **s2i16_dtypes = get_dtypes(this, &PyArray_Int16DType);
-
-    PyArrayMethod_Spec *StringToInt16CastSpec =
-            get_cast_spec(s2i16_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, s2i16_dtypes, s2i16_slots);
-
-    PyArray_DTypeMeta **i162s_dtypes = get_dtypes(&PyArray_Int16DType, this);
-
-    PyArrayMethod_Spec *Int16ToStringCastSpec =
-            get_cast_spec(i162s_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, i162s_dtypes, i162s_slots);
-
-    PyArray_DTypeMeta **s2ui16_dtypes = get_dtypes(this, &PyArray_UInt16DType);
-
-    PyArrayMethod_Spec *StringToUInt16CastSpec = get_cast_spec(
-            s2ui16_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2ui16_dtypes, s2ui16_slots);
-
-    PyArray_DTypeMeta **ui162s_dtypes = get_dtypes(&PyArray_UInt16DType, this);
-
-    PyArrayMethod_Spec *UInt16ToStringCastSpec = get_cast_spec(
-            ui162s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            ui162s_dtypes, ui162s_slots);
-
-    PyArray_DTypeMeta **s2i32_dtypes = get_dtypes(this, &PyArray_Int32DType);
-
-    PyArrayMethod_Spec *StringToInt32CastSpec =
-            get_cast_spec(s2i32_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, s2i32_dtypes, s2i32_slots);
-
-    PyArray_DTypeMeta **i322s_dtypes = get_dtypes(&PyArray_Int32DType, this);
-
-    PyArrayMethod_Spec *Int32ToStringCastSpec =
-            get_cast_spec(i322s_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, i322s_dtypes, i322s_slots);
-
-    PyArray_DTypeMeta **s2ui32_dtypes = get_dtypes(this, &PyArray_UInt32DType);
-
-    PyArrayMethod_Spec *StringToUInt32CastSpec = get_cast_spec(
-            s2ui32_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2ui32_dtypes, s2ui32_slots);
-
-    PyArray_DTypeMeta **ui322s_dtypes = get_dtypes(&PyArray_UInt32DType, this);
-
-    PyArrayMethod_Spec *UInt32ToStringCastSpec = get_cast_spec(
-            ui322s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            ui322s_dtypes, ui322s_slots);
-
-    PyArray_DTypeMeta **s2i64_dtypes = get_dtypes(this, &PyArray_Int64DType);
-
-    PyArrayMethod_Spec *StringToInt64CastSpec =
-            get_cast_spec(s2i64_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, s2i64_dtypes, s2i64_slots);
-
-    PyArray_DTypeMeta **i642s_dtypes = get_dtypes(&PyArray_Int64DType, this);
-
-    PyArrayMethod_Spec *Int64ToStringCastSpec =
-            get_cast_spec(i642s_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, i642s_dtypes, i642s_slots);
-
+    INT_DTYPES_AND_CAST_SPEC(i8, Int8)
+    INT_DTYPES_AND_CAST_SPEC(i16, Int16)
+    INT_DTYPES_AND_CAST_SPEC(i32, Int32)
+    INT_DTYPES_AND_CAST_SPEC(i64, Int64)
 #if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
-    PyArray_DTypeMeta **s2byte_dtypes = get_dtypes(this, &PyArray_ByteDType);
-
-    PyArrayMethod_Spec *StringToByteCastSpec = get_cast_spec(
-            s2byte_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2byte_dtypes, s2byte_slots);
-
-    PyArray_DTypeMeta **byte2s_dtypes = get_dtypes(&PyArray_ByteDType, this);
-
-    PyArrayMethod_Spec *ByteToStringCastSpec = get_cast_spec(
-            byte2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            byte2s_dtypes, byte2s_slots);
-
-    PyArray_DTypeMeta **s2ubyte_dtypes = get_dtypes(this, &PyArray_UByteDType);
-
-    PyArrayMethod_Spec *StringToUByteCastSpec = get_cast_spec(
-            s2ubyte_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2ubyte_dtypes, s2ubyte_slots);
-
-    PyArray_DTypeMeta **ubyte2s_dtypes = get_dtypes(&PyArray_UByteDType, this);
-
-    PyArrayMethod_Spec *UByteToStringCastSpec = get_cast_spec(
-            ubyte2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            ubyte2s_dtypes, ubyte2s_slots);
+    INT_DTYPES_AND_CAST_SPEC(byte, Byte)
 #endif
-
 #if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
-    PyArray_DTypeMeta **s2short_dtypes = get_dtypes(this, &PyArray_ShortDType);
-
-    PyArrayMethod_Spec *StringToShortCastSpec = get_cast_spec(
-            s2short_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2short_dtypes, s2short_slots);
-
-    PyArray_DTypeMeta **short2s_dtypes = get_dtypes(&PyArray_ShortDType, this);
-
-    PyArrayMethod_Spec *ShortToStringCastSpec = get_cast_spec(
-            short2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            short2s_dtypes, short2s_slots);
-
-    PyArray_DTypeMeta **s2ushort_dtypes =
-            get_dtypes(this, &PyArray_UShortDType);
-
-    PyArrayMethod_Spec *StringToUShortCastSpec = get_cast_spec(
-            s2ushort_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2ushort_dtypes, s2ushort_slots);
-
-    PyArray_DTypeMeta **ushort2s_dtypes =
-            get_dtypes(&PyArray_UShortDType, this);
-
-    PyArrayMethod_Spec *UShortToStringCastSpec = get_cast_spec(
-            ushort2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            ushort2s_dtypes, ushort2s_slots);
+    INT_DTYPES_AND_CAST_SPEC(short, Short)
 #endif
-
 #if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
-    PyArray_DTypeMeta **s2int_dtypes = get_dtypes(this, &PyArray_IntDType);
-
-    PyArrayMethod_Spec *StringToIntCastSpec =
-            get_cast_spec(s2int_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, s2int_dtypes, s2int_slots);
-
-    PyArray_DTypeMeta **int2s_dtypes = get_dtypes(&PyArray_IntDType, this);
-
-    PyArrayMethod_Spec *IntToStringCastSpec =
-            get_cast_spec(int2s_name, NPY_UNSAFE_CASTING,
-                          NPY_METH_REQUIRES_PYAPI, int2s_dtypes, int2s_slots);
-
-    PyArray_DTypeMeta **s2uint_dtypes = get_dtypes(this, &PyArray_UIntDType);
-
-    PyArrayMethod_Spec *StringToUIntCastSpec = get_cast_spec(
-            s2uint_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2uint_dtypes, s2uint_slots);
-
-    PyArray_DTypeMeta **uint2s_dtypes = get_dtypes(&PyArray_UIntDType, this);
-
-    PyArrayMethod_Spec *UIntToStringCastSpec = get_cast_spec(
-            uint2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            uint2s_dtypes, uint2s_slots);
+    INT_DTYPES_AND_CAST_SPEC(int, Int)
 #endif
-
 #if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
-    PyArray_DTypeMeta **s2longlong_dtypes =
-            get_dtypes(this, &PyArray_LongLongDType);
-
-    PyArrayMethod_Spec *StringToLongLongCastSpec = get_cast_spec(
-            s2longlong_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2longlong_dtypes, s2longlong_slots);
-
-    PyArray_DTypeMeta **longlong2s_dtypes =
-            get_dtypes(&PyArray_LongLongDType, this);
-
-    PyArrayMethod_Spec *LongLongToStringCastSpec = get_cast_spec(
-            longlong2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            longlong2s_dtypes, longlong2s_slots);
-
-    PyArray_DTypeMeta **s2ulonglong_dtypes =
-            get_dtypes(this, &PyArray_ULongLongDType);
-
-    PyArrayMethod_Spec *StringToULongLongCastSpec = get_cast_spec(
-            s2ulonglong_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2ulonglong_dtypes, s2ulonglong_slots);
-
-    PyArray_DTypeMeta **ulonglong2s_dtypes =
-            get_dtypes(&PyArray_ULongLongDType, this);
-
-    PyArrayMethod_Spec *ULongLongToStringCastSpec = get_cast_spec(
-            ulonglong2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            ulonglong2s_dtypes, ulonglong2s_slots);
+    INT_DTYPES_AND_CAST_SPEC(longlong, LongLong)
 #endif
-
-    PyArray_DTypeMeta **s2ui64_dtypes = get_dtypes(this, &PyArray_UInt64DType);
-
-    PyArrayMethod_Spec *StringToUInt64CastSpec = get_cast_spec(
-            s2ui64_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            s2ui64_dtypes, s2ui64_slots);
-
-    PyArray_DTypeMeta **ui642s_dtypes = get_dtypes(&PyArray_UInt64DType, this);
-
-    PyArrayMethod_Spec *UInt64ToStringCastSpec = get_cast_spec(
-            ui642s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
-            ui642s_dtypes, ui642s_slots);
 
     PyArrayMethod_Spec **casts = NULL;
 

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -499,6 +499,8 @@ static PyType_Slot b2s_slots[] = {{NPY_METH_resolve_descriptors,
 
 static char *b2s_name = "cast_Bool_to_StringDType";
 
+// casts between string and (u)int dtypes
+
 static PyObject *
 string_to_pylong(char *in)
 {
@@ -691,23 +693,7 @@ uint_to_string(unsigned long long in, char *out)
                                                                              \
     PyArrayMethod_Spec *typename##ToStringCastSpec = get_cast_spec(          \
             shortname##2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI, \
-            shortname##2s_dtypes, shortname##2s_slots);                      \
-                                                                             \
-    PyArray_DTypeMeta **s2u##shortname##_dtypes =                            \
-            get_dtypes(this, &PyArray_U##typename##DType);                   \
-                                                                             \
-    PyArrayMethod_Spec *StringToU##typename##CastSpec =                      \
-            get_cast_spec(s2u##shortname##_name, NPY_UNSAFE_CASTING,         \
-                          NPY_METH_REQUIRES_PYAPI, s2u##shortname##_dtypes,  \
-                          s2u##shortname##_slots);                           \
-                                                                             \
-    PyArray_DTypeMeta **u##shortname##2s_dtypes =                            \
-            get_dtypes(&PyArray_U##typename##DType, this);                   \
-                                                                             \
-    PyArrayMethod_Spec *U##typename##ToStringCastSpec =                      \
-            get_cast_spec(u##shortname##2s_name, NPY_UNSAFE_CASTING,         \
-                          NPY_METH_REQUIRES_PYAPI, u##shortname##2s_dtypes,  \
-                          u##shortname##2s_slots);
+            shortname##2s_dtypes, shortname##2s_slots);
 
 STRING_TO_INT(int8, int, i8, NPY_INT8, lli, npy_longlong)
 INT_TO_STRING(int8, int, i8, long long)
@@ -757,17 +743,17 @@ STRING_TO_INT(ulonglong, uint, ulonglong, NPY_ULONGLONG, llu, npy_ulonglong)
 INT_TO_STRING(ulonglong, uint, ulonglong, unsigned long long)
 #endif
 
-STRING_TO_INT(uint8, uint, ui8, NPY_UINT8, llu, npy_ulonglong)
-INT_TO_STRING(uint8, uint, ui8, unsigned long long)
+STRING_TO_INT(uint8, uint, u8, NPY_UINT8, llu, npy_ulonglong)
+INT_TO_STRING(uint8, uint, u8, unsigned long long)
 
-STRING_TO_INT(uint16, uint, ui16, NPY_UINT16, llu, npy_ulonglong)
-INT_TO_STRING(uint16, uint, ui16, unsigned long long)
+STRING_TO_INT(uint16, uint, u16, NPY_UINT16, llu, npy_ulonglong)
+INT_TO_STRING(uint16, uint, u16, unsigned long long)
 
-STRING_TO_INT(uint32, uint, ui32, NPY_UINT32, llu, npy_ulonglong)
-INT_TO_STRING(uint32, uint, ui32, unsigned long long)
+STRING_TO_INT(uint32, uint, u32, NPY_UINT32, llu, npy_ulonglong)
+INT_TO_STRING(uint32, uint, u32, unsigned long long)
 
-STRING_TO_INT(uint64, uint, ui64, NPY_UINT64, llu, npy_ulonglong)
-INT_TO_STRING(uint64, uint, ui64, unsigned long long)
+STRING_TO_INT(uint64, uint, u64, NPY_UINT64, llu, npy_ulonglong)
+INT_TO_STRING(uint64, uint, u64, unsigned long long)
 
 PyArrayMethod_Spec *
 get_cast_spec(const char *name, NPY_CASTING casting,
@@ -880,17 +866,25 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
     INT_DTYPES_AND_CAST_SPEC(i16, Int16)
     INT_DTYPES_AND_CAST_SPEC(i32, Int32)
     INT_DTYPES_AND_CAST_SPEC(i64, Int64)
+    INT_DTYPES_AND_CAST_SPEC(u8, UInt8)
+    INT_DTYPES_AND_CAST_SPEC(u16, UInt16)
+    INT_DTYPES_AND_CAST_SPEC(u32, UInt32)
+    INT_DTYPES_AND_CAST_SPEC(u64, UInt64)
 #if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
     INT_DTYPES_AND_CAST_SPEC(byte, Byte)
+    INT_DTYPES_AND_CAST_SPEC(ubyte, UByte)
 #endif
 #if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
     INT_DTYPES_AND_CAST_SPEC(short, Short)
+    INT_DTYPES_AND_CAST_SPEC(ushort, UShort)
 #endif
 #if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
     INT_DTYPES_AND_CAST_SPEC(int, Int)
+    INT_DTYPES_AND_CAST_SPEC(uint, UInt)
 #endif
 #if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
     INT_DTYPES_AND_CAST_SPEC(longlong, LongLong)
+    INT_DTYPES_AND_CAST_SPEC(ulonglong, ULongLong)
 #endif
 
     PyArrayMethod_Spec **casts = NULL;

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -689,6 +689,42 @@ INT_TO_STRING(int32, int, i32, long long)
 STRING_TO_INT(int64, int, i64, NPY_INT64, lli, npy_longlong)
 INT_TO_STRING(int64, int, i64, long long)
 
+#if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
+// byte doesn't have a bitsized alias
+STRING_TO_INT(byte, int, byte, NPY_BYTE, lli, npy_byte)
+INT_TO_STRING(byte, int, byte, long long)
+
+STRING_TO_INT(ubyte, uint, ubyte, NPY_UBYTE, llu, npy_ubyte)
+INT_TO_STRING(ubyte, uint, ubyte, unsigned long long)
+#endif
+
+#if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
+// short doesn't have a bitsized alias
+STRING_TO_INT(short, int, short, NPY_SHORT, lli, npy_short)
+INT_TO_STRING(short, int, short, long long)
+
+STRING_TO_INT(ushort, uint, ushort, NPY_USHORT, llu, npy_ushort)
+INT_TO_STRING(ushort, uint, ushort, unsigned long long)
+#endif
+
+#if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
+// int doesn't have a bitsized alias
+STRING_TO_INT(int, int, int, NPY_INT, lli, npy_int)
+INT_TO_STRING(int, int, int, long long)
+
+STRING_TO_INT(uint, uint, uint, NPY_UINT, llu, npy_uint)
+INT_TO_STRING(uint, uint, uint, unsigned long long)
+#endif
+
+#if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
+// long long doesn't have a bitsized alias
+STRING_TO_INT(longlong, int, longlong, NPY_LONGLONG, lli, npy_longlong)
+INT_TO_STRING(longlong, int, longlong, long long)
+
+STRING_TO_INT(ulonglong, uint, ulonglong, NPY_ULONGLONG, llu, npy_ulonglong)
+INT_TO_STRING(ulonglong, uint, ulonglong, unsigned long long)
+#endif
+
 STRING_TO_INT(uint8, uint, ui8, NPY_UINT8, llu, npy_ulonglong)
 INT_TO_STRING(uint8, uint, ui8, unsigned long long)
 
@@ -754,6 +790,19 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
     int is_pandas = (this == (PyArray_DTypeMeta *)&PandasStringDType);
 
     int num_casts = 21;
+
+#if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
+    num_casts += 4;
+#endif
+#if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
+    num_casts += 4;
+#endif
+#if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
+    num_casts += 4;
+#endif
+#if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
+    num_casts += 4;
+#endif
 
     if (is_pandas) {
         num_casts += 2;
@@ -879,6 +928,116 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
             get_cast_spec(i642s_name, NPY_UNSAFE_CASTING,
                           NPY_METH_REQUIRES_PYAPI, i642s_dtypes, i642s_slots);
 
+#if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
+    PyArray_DTypeMeta **s2byte_dtypes = get_dtypes(this, &PyArray_ByteDType);
+
+    PyArrayMethod_Spec *StringToByteCastSpec = get_cast_spec(
+            s2byte_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            s2byte_dtypes, s2byte_slots);
+
+    PyArray_DTypeMeta **byte2s_dtypes = get_dtypes(&PyArray_ByteDType, this);
+
+    PyArrayMethod_Spec *ByteToStringCastSpec = get_cast_spec(
+            byte2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            byte2s_dtypes, byte2s_slots);
+
+    PyArray_DTypeMeta **s2ubyte_dtypes = get_dtypes(this, &PyArray_UByteDType);
+
+    PyArrayMethod_Spec *StringToUByteCastSpec = get_cast_spec(
+            s2ubyte_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            s2ubyte_dtypes, s2ubyte_slots);
+
+    PyArray_DTypeMeta **ubyte2s_dtypes = get_dtypes(&PyArray_UByteDType, this);
+
+    PyArrayMethod_Spec *UByteToStringCastSpec = get_cast_spec(
+            ubyte2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            ubyte2s_dtypes, ubyte2s_slots);
+#endif
+
+#if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
+    PyArray_DTypeMeta **s2short_dtypes = get_dtypes(this, &PyArray_ShortDType);
+
+    PyArrayMethod_Spec *StringToShortCastSpec = get_cast_spec(
+            s2short_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            s2short_dtypes, s2short_slots);
+
+    PyArray_DTypeMeta **short2s_dtypes = get_dtypes(&PyArray_ShortDType, this);
+
+    PyArrayMethod_Spec *ShortToStringCastSpec = get_cast_spec(
+            short2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            short2s_dtypes, short2s_slots);
+
+    PyArray_DTypeMeta **s2ushort_dtypes =
+            get_dtypes(this, &PyArray_UShortDType);
+
+    PyArrayMethod_Spec *StringToUShortCastSpec = get_cast_spec(
+            s2ushort_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            s2ushort_dtypes, s2ushort_slots);
+
+    PyArray_DTypeMeta **ushort2s_dtypes =
+            get_dtypes(&PyArray_UShortDType, this);
+
+    PyArrayMethod_Spec *UShortToStringCastSpec = get_cast_spec(
+            ushort2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            ushort2s_dtypes, ushort2s_slots);
+#endif
+
+#if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
+    PyArray_DTypeMeta **s2int_dtypes = get_dtypes(this, &PyArray_IntDType);
+
+    PyArrayMethod_Spec *StringToIntCastSpec =
+            get_cast_spec(s2int_name, NPY_UNSAFE_CASTING,
+                          NPY_METH_REQUIRES_PYAPI, s2int_dtypes, s2int_slots);
+
+    PyArray_DTypeMeta **int2s_dtypes = get_dtypes(&PyArray_IntDType, this);
+
+    PyArrayMethod_Spec *IntToStringCastSpec =
+            get_cast_spec(int2s_name, NPY_UNSAFE_CASTING,
+                          NPY_METH_REQUIRES_PYAPI, int2s_dtypes, int2s_slots);
+
+    PyArray_DTypeMeta **s2uint_dtypes = get_dtypes(this, &PyArray_UIntDType);
+
+    PyArrayMethod_Spec *StringToUIntCastSpec = get_cast_spec(
+            s2uint_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            s2uint_dtypes, s2uint_slots);
+
+    PyArray_DTypeMeta **uint2s_dtypes = get_dtypes(&PyArray_UIntDType, this);
+
+    PyArrayMethod_Spec *UIntToStringCastSpec = get_cast_spec(
+            uint2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            uint2s_dtypes, uint2s_slots);
+#endif
+
+#if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
+    PyArray_DTypeMeta **s2longlong_dtypes =
+            get_dtypes(this, &PyArray_LongLongDType);
+
+    PyArrayMethod_Spec *StringToLongLongCastSpec = get_cast_spec(
+            s2longlong_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            s2longlong_dtypes, s2longlong_slots);
+
+    PyArray_DTypeMeta **longlong2s_dtypes =
+            get_dtypes(&PyArray_LongLongDType, this);
+
+    PyArrayMethod_Spec *LongLongToStringCastSpec = get_cast_spec(
+            longlong2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            longlong2s_dtypes, longlong2s_slots);
+
+    PyArray_DTypeMeta **s2ulonglong_dtypes =
+            get_dtypes(this, &PyArray_ULongLongDType);
+
+    PyArrayMethod_Spec *StringToULongLongCastSpec = get_cast_spec(
+            s2ulonglong_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            s2ulonglong_dtypes, s2ulonglong_slots);
+
+    PyArray_DTypeMeta **ulonglong2s_dtypes =
+            get_dtypes(&PyArray_ULongLongDType, this);
+
+    PyArrayMethod_Spec *ULongLongToStringCastSpec = get_cast_spec(
+            ulonglong2s_name, NPY_UNSAFE_CASTING, NPY_METH_REQUIRES_PYAPI,
+            ulonglong2s_dtypes, ulonglong2s_slots);
+#endif
+
     PyArray_DTypeMeta **s2ui64_dtypes = get_dtypes(this, &PyArray_UInt64DType);
 
     PyArrayMethod_Spec *StringToUInt64CastSpec = get_cast_spec(
@@ -895,37 +1054,64 @@ get_casts(PyArray_DTypeMeta *this, PyArray_DTypeMeta *other)
 
     casts = malloc((num_casts + 1) * sizeof(PyArrayMethod_Spec *));
 
-    casts[0] = ThisToThisCastSpec;
-    casts[1] = UnicodeToStringCastSpec;
-    casts[2] = StringToUnicodeCastSpec;
-    casts[3] = StringToBoolCastSpec;
-    casts[4] = BoolToStringCastSpec;
-    casts[5] = StringToInt8CastSpec;
-    casts[6] = Int8ToStringCastSpec;
-    casts[7] = StringToInt16CastSpec;
-    casts[8] = Int16ToStringCastSpec;
-    casts[9] = StringToInt32CastSpec;
-    casts[10] = Int32ToStringCastSpec;
-    casts[11] = StringToInt64CastSpec;
-    casts[12] = Int64ToStringCastSpec;
-    casts[13] = StringToUInt8CastSpec;
-    casts[14] = UInt8ToStringCastSpec;
-    casts[15] = StringToUInt16CastSpec;
-    casts[16] = UInt16ToStringCastSpec;
-    casts[17] = StringToUInt32CastSpec;
-    casts[18] = UInt32ToStringCastSpec;
-    casts[19] = StringToUInt64CastSpec;
-    casts[20] = UInt64ToStringCastSpec;
+    int cast_i = 0;
+
+    casts[cast_i++] = ThisToThisCastSpec;
+    casts[cast_i++] = UnicodeToStringCastSpec;
+    casts[cast_i++] = StringToUnicodeCastSpec;
+    casts[cast_i++] = StringToBoolCastSpec;
+    casts[cast_i++] = BoolToStringCastSpec;
+    casts[cast_i++] = StringToInt8CastSpec;
+    casts[cast_i++] = Int8ToStringCastSpec;
+    casts[cast_i++] = StringToInt16CastSpec;
+    casts[cast_i++] = Int16ToStringCastSpec;
+    casts[cast_i++] = StringToInt32CastSpec;
+    casts[cast_i++] = Int32ToStringCastSpec;
+    casts[cast_i++] = StringToInt64CastSpec;
+    casts[cast_i++] = Int64ToStringCastSpec;
+    casts[cast_i++] = StringToUInt8CastSpec;
+    casts[cast_i++] = UInt8ToStringCastSpec;
+    casts[cast_i++] = StringToUInt16CastSpec;
+    casts[cast_i++] = UInt16ToStringCastSpec;
+    casts[cast_i++] = StringToUInt32CastSpec;
+    casts[cast_i++] = UInt32ToStringCastSpec;
+    casts[cast_i++] = StringToUInt64CastSpec;
+    casts[cast_i++] = UInt64ToStringCastSpec;
+#if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
+    casts[cast_i++] = StringToByteCastSpec;
+    casts[cast_i++] = ByteToStringCastSpec;
+    casts[cast_i++] = StringToUByteCastSpec;
+    casts[cast_i++] = UByteToStringCastSpec;
+#endif
+#if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
+    casts[cast_i++] = StringToShortCastSpec;
+    casts[cast_i++] = ShortToStringCastSpec;
+    casts[cast_i++] = StringToUShortCastSpec;
+    casts[cast_i++] = UShortToStringCastSpec;
+#endif
+#if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
+    casts[cast_i++] = StringToIntCastSpec;
+    casts[cast_i++] = IntToStringCastSpec;
+    casts[cast_i++] = StringToUIntCastSpec;
+    casts[cast_i++] = UIntToStringCastSpec;
+#endif
+#if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
+    casts[cast_i++] = StringToLongLongCastSpec;
+    casts[cast_i++] = LongLongToStringCastSpec;
+    casts[cast_i++] = StringToULongLongCastSpec;
+    casts[cast_i++] = ULongLongToStringCastSpec;
+#endif
     if (is_pandas) {
-        casts[21] = ThisToOtherCastSpec;
-        casts[22] = OtherToThisCastSpec;
-        casts[23] = NULL;
+        casts[cast_i++] = ThisToOtherCastSpec;
+        casts[cast_i++] = OtherToThisCastSpec;
+        casts[cast_i++] = NULL;
     }
     else {
-        casts[21] = NULL;
+        casts[cast_i++] = NULL;
     }
 
     assert(casts[num_casts] == NULL);
+    assert(cast_i == num_casts + 1);
 
     return casts;
 }

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -376,7 +376,7 @@ def test_cast_from_bool(dtype, strings, cast_answer):
 
 @pytest.mark.parametrize("bitsize", [8, 16, 32, 64])
 @pytest.mark.parametrize("signed", [True, False])
-def test_integer_casts(dtype, bitsize, signed):
+def test_sized_integer_casts(dtype, bitsize, signed):
     idtype = f"int{bitsize}"
     if signed:
         inp = [-(2**p - 1) for p in reversed(range(bitsize - 1))]
@@ -396,6 +396,16 @@ def test_integer_casts(dtype, bitsize, signed):
     oob = [str(2**bitsize), str(-(2**bitsize))]
     with pytest.raises(OverflowError):
         np.array(oob, dtype=dtype).astype(idtype)
+
+
+@pytest.mark.parametrize("typename", ["byte", "short", "int", "longlong"])
+@pytest.mark.parametrize("signed", ["", "u"])
+def test_unsized_integer_casts(dtype, typename, signed):
+    idtype = f"{signed}{typename}"
+
+    inp = [1, 2, 3, 4]
+    ainp = np.array(inp, dtype=idtype)
+    np.testing.assert_array_equal(ainp, ainp.astype(dtype).astype(idtype))
 
 
 def test_take(dtype, string_list):


### PR DESCRIPTION
I've also used macros in a couple of places to reduce the amount of copy/paste in this file.