### PR TITLE
Add multiply ufunc

### DIFF
--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -450,19 +450,23 @@ def test_ufuncs_minmax(dtype, string_list, ufunc, func):
 
 
 @pytest.mark.parametrize(
-    "other_strings",
+    "ufunc,other,func",
     [
-        ["abc", "def", "ghi", "🤣", "📵", "😰"],
-        ["🚜", "🙃", "😾", "😹", "🚠", "🚌"],
-        ["🥦", "¨", "⨯", "∰ ", "⨌ ", "⎶ "],
+        ("add", "asdf", lambda arr, b: [x + b for x in arr]),
+        (
+            "add",
+            np.array(["a", "b", "c", "d", "e", "f"], dtype=StringDType()),
+            lambda arr1, arr2: [x + y for x, y in zip(arr1, arr2)],
+        ),
+        ("multiply", 3, lambda arr, b: [x * b for x in arr]),
     ],
 )
-def test_ufunc_add(dtype, string_list, other_strings):
-    arr1 = np.array(string_list, dtype=dtype)
-    arr2 = np.array(other_strings, dtype=dtype)
+def test_binary_ufuncs(dtype, string_list, ufunc, other, func):
+    """Test the two-argument ufuncs match python builtin behavior."""
+    arr = np.array(string_list, dtype=StringDType())
     np.testing.assert_array_equal(
-        np.add(arr1, arr2),
-        np.array([a + b for a, b in zip(arr1, arr2)], dtype=dtype),
+        getattr(np, ufunc)(arr, other),
+        np.array(func(string_list, other), dtype=StringDType()),
     )
 
 


### PR DESCRIPTION
This is a little ugly because I need to use some macros to make multiply work for all integer dtypes. 

Also I learned doing this that python's multiply operator doesn't care about the order of operands if you're doing string * int:

```python
>>> 3 * 'x'
'xxx'
>>> 'x' * 3
'xxx'
```

So following that example I added implementations for both possibilities.