### PR TITLE
build in release mode by default; fix bugs revealed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
           python-version: "3.10"
       - name: Install build and test dependencies
         run: |
-          pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-          pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+          pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+          pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
           python -m pip install -U pip build pytest unyt wheel meson ninja meson-python patchelf
       - name: Install asciidtype
         working-directory: asciidtype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Install build and test dependencies
         run: |
           pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-          python -m pip install -U pip build pytest unyt wheel meson ninja meson-python patchelf pandas
+          pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+          python -m pip install -U pip build pytest unyt wheel meson ninja meson-python patchelf
       - name: Install asciidtype
         working-directory: asciidtype
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
           python-version: "3.10"
       - name: Install build and test dependencies
         run: |
-          pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-          pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
+          pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+          pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
           python -m pip install -U pip build pytest unyt wheel meson ninja meson-python patchelf
       - name: Install asciidtype
         working-directory: asciidtype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.10"
       - name: Install build and test dependencies
         run: |
-          pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+          pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
           pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
           python -m pip install -U pip build pytest unyt wheel meson ninja meson-python patchelf
       - name: Install asciidtype

--- a/stringdtype/pyproject.toml
+++ b/stringdtype/pyproject.toml
@@ -35,6 +35,6 @@ per-file-ignores = {"__init__.py" = ["F401"]}
 
 [tool.meson-python.args]
 dist = []
-setup = ["-Dbuildtype=debug"]
+setup = []
 compile = []
 install = []

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -388,6 +388,7 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
             }
             else {
                 this_string = (unsigned char *)(default_string.buf);
+                n_bytes = default_string.len;
             }
         }
         else {

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -661,7 +661,7 @@ StringDType_richcompare(PyObject *self, PyObject *other, int op)
     StringDTypeObject *sself = (StringDTypeObject *)self;
     StringDTypeObject *sother = (StringDTypeObject *)other;
 
-    int eq;
+    int eq = 0;
     PyObject *sna = sself->na_object;
     PyObject *ona = sother->na_object;
 
@@ -706,6 +706,22 @@ StringDType_richcompare(PyObject *self, PyObject *other, int op)
     return ret;
 }
 
+static Py_hash_t
+StringDType_hash(StringDTypeObject *self)
+{
+    PyObject *hash_tup = NULL;
+    if (self->na_object != NULL) {
+        hash_tup = Py_BuildValue("(iO)", self->coerce, self->na_object);
+    }
+    else {
+        hash_tup = Py_BuildValue("(i)", self->coerce);
+    }
+
+    Py_hash_t ret = PyObject_Hash(hash_tup);
+    Py_DECREF(hash_tup);
+    return ret;
+}
+
 /*
  * This is the basic things that you need to create a Python Type/Class in C.
  * However, there is a slight difference here because we create a
@@ -724,6 +740,7 @@ StringDType_type StringDType = {
                 .tp_methods = StringDType_methods,
                 .tp_members = StringDType_members,
                 .tp_richcompare = StringDType_richcompare,
+                .tp_hash = StringDType_hash,
         }}},
         /* rest, filled in during DTypeMeta initialization */
 };

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -707,14 +707,15 @@ StringDType_richcompare(PyObject *self, PyObject *other, int op)
 }
 
 static Py_hash_t
-StringDType_hash(StringDTypeObject *self)
+StringDType_hash(PyObject *self)
 {
+    StringDTypeObject *sself = (StringDTypeObject *)self;
     PyObject *hash_tup = NULL;
-    if (self->na_object != NULL) {
-        hash_tup = Py_BuildValue("(iO)", self->coerce, self->na_object);
+    if (sself->na_object != NULL) {
+        hash_tup = Py_BuildValue("(iO)", sself->coerce, sself->na_object);
     }
     else {
-        hash_tup = Py_BuildValue("(i)", self->coerce);
+        hash_tup = Py_BuildValue("(i)", sself->coerce);
     }
 
     Py_hash_t ret = PyObject_Hash(hash_tup);

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -871,17 +871,22 @@ init_ufunc(PyObject *numpy, const char *ufunc_name, PyArray_DTypeMeta **dtypes,
             .casting = casting,
             .flags = flags,
             .dtypes = dtypes,
+            .slots = NULL,
     };
 
+    PyType_Slot resolve_slots[] = {
+            {NPY_METH_resolve_descriptors, resolve_func},
+            {NPY_METH_strided_loop, loop_func},
+            {0, NULL}};
+
+    PyType_Slot strided_slots[] = {{NPY_METH_strided_loop, loop_func},
+                                   {0, NULL}};
+
     if (resolve_func == NULL) {
-        PyType_Slot slots[] = {{NPY_METH_strided_loop, loop_func}, {0, NULL}};
-        spec.slots = slots;
+        spec.slots = strided_slots;
     }
     else {
-        PyType_Slot slots[] = {{NPY_METH_resolve_descriptors, resolve_func},
-                               {NPY_METH_strided_loop, loop_func},
-                               {0, NULL}};
-        spec.slots = slots;
+        spec.slots = resolve_slots;
     }
 
     if (PyUFunc_AddLoopFromSpec(ufunc, &spec) < 0) {

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -49,17 +49,24 @@ def dtype(na_object, coerce):
 
 
 def test_dtype_creation():
+    hashes = set()
     dt = StringDType()
     assert not hasattr(dt, "na_object") and dt.coerce == 1
+    hashes.add(hash(dt))
 
     dt = StringDType(na_object=None)
     assert dt.na_object is None and dt.coerce == 1
+    hashes.add(hash(dt))
 
     dt = StringDType(coerce=False)
     assert not hasattr(dt, "na_object") and dt.coerce == 0
+    hashes.add(hash(dt))
 
     dt = StringDType(na_object=None, coerce=False)
     assert dt.na_object is None and dt.coerce == 0
+    hashes.add(hash(dt))
+
+    assert len(hashes) == 4
 
 
 def test_scalar_creation():


### PR DESCRIPTION
I built in release mode for the first time in a while working on the NEP and found some issues. This fixes them, it also makes the project build in release mode by default. I can override that locally if I need a debug build.

I also added a `__hash__` implementation, which is needed now that there is a rich comparison implementation, I don't see a reason not to allow dtype instances as dict keys since there is a well-defined sense of equality and no public internal state.