### PR TITLE
Don't store terminating nulls in the string storage

### DIFF
--- a/stringdtype/stringdtype/src/casts.h
+++ b/stringdtype/stringdtype/src/casts.h
@@ -14,7 +14,4 @@
 PyArrayMethod_Spec **
 get_casts();
 
-size_t
-utf8_char_to_ucs4_code(unsigned char *, Py_UCS4 *);
-
 #endif /* _NPY_CASTS_H */

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -107,13 +107,3 @@ ss_isnull(const ss *in)
     }
     return 0;
 }
-
-const char *
-ss_data(const ss *in, const char *default_str)
-{
-    if (ss_isnull(in)) {
-        return default_str;
-    }
-
-    return in->buf;
-}

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -1,6 +1,8 @@
 #include "static_string.h"
 
-const ss EMPTY_STRING = {0, ""};
+// defined this way so it has an in-memory representation that is distinct
+// from NULL, allowing us to use NULL to represent a sentinel value
+const ss EMPTY_STRING = {0, "\0"};
 
 int
 ssnewlen(const char *init, size_t len, ss *to_init)
@@ -10,12 +12,11 @@ ssnewlen(const char *init, size_t len, ss *to_init)
     }
 
     if (len == 0) {
-        to_init->len = 0;
-        to_init->buf = EMPTY_STRING.buf;
+        *to_init = EMPTY_STRING;
+        return 0;
     }
 
-    // one extra byte for null terminator
-    char *ret_buf = (char *)malloc(sizeof(char) * (len + 1));
+    char *ret_buf = (char *)malloc(sizeof(char) * len);
 
     if (ret_buf == NULL) {
         return -1;
@@ -23,11 +24,7 @@ ssnewlen(const char *init, size_t len, ss *to_init)
 
     to_init->len = len;
 
-    if (len > 0) {
-        memcpy(ret_buf, init, len);
-    }
-
-    ret_buf[len] = '\0';
+    memcpy(ret_buf, init, len);
 
     to_init->buf = ret_buf;
 
@@ -37,10 +34,8 @@ ssnewlen(const char *init, size_t len, ss *to_init)
 void
 ssfree(ss *str)
 {
-    if (str->buf != NULL) {
-        if (str->buf != EMPTY_STRING.buf) {
-            free(str->buf);
-        }
+    if (str->buf != NULL && str->buf != EMPTY_STRING.buf) {
+        free(str->buf);
         str->buf = NULL;
     }
     str->len = 0;
@@ -66,16 +61,42 @@ ssnewemptylen(size_t num_bytes, ss *out)
         return -2;
     }
 
-    char *buf = (char *)malloc(sizeof(char) * (num_bytes + 1));
+    out->len = num_bytes;
+
+    if (num_bytes == 0) {
+        *out = EMPTY_STRING;
+        return 0;
+    }
+
+    char *buf = (char *)malloc(sizeof(char) * num_bytes);
 
     if (buf == NULL) {
         return -1;
     }
 
     out->buf = buf;
-    out->len = num_bytes;
 
     return 0;
+}
+
+// same semantics as strcmp
+int
+sscmp(const ss *s1, const ss *s2)
+{
+    size_t minlen = s1->len < s2->len ? s1->len : s2->len;
+
+    int cmp = strncmp(s1->buf, s2->buf, minlen);
+
+    if (cmp == 0) {
+        if (s1->len > minlen) {
+            return 1;
+        }
+        if (s2->len > minlen) {
+            return -1;
+        }
+    }
+
+    return cmp;
 }
 
 int
@@ -85,4 +106,14 @@ ss_isnull(const ss *in)
         return 1;
     }
     return 0;
+}
+
+const char *
+ss_data(const ss *in, const char *default_str)
+{
+    if (ss_isnull(in)) {
+        return default_str;
+    }
+
+    return in->buf;
 }

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -41,4 +41,9 @@ ssnewemptylen(size_t num_bytes, ss *out);
 int
 ss_isnull(const ss *in);
 
+// Compare two strings. Has the same sematics as strcmp passed null-terminated
+// C strings with the content of *s1* and *s2*.
+int
+sscmp(const ss *s1, const ss *s2);
+
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -76,7 +76,6 @@ multiply_resolve_descriptors(
             for (size_t i = 0; i < (size_t)factor; i++) {                    \
                 memcpy(os->buf + i * is->len, is->buf, is->len);             \
             }                                                                \
-            os->buf[newlen] = '\0';                                          \
                                                                              \
             sin += s_stride;                                                 \
             iin += i_stride;                                                 \
@@ -246,7 +245,6 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
 
         memcpy(os->buf, s1->buf, s1->len);
         memcpy(os->buf + s1->len, s2->buf, s2->len);
-        os->buf[newlen] = '\0';
 
     next_step:
         in1 += in1_stride;
@@ -508,7 +506,7 @@ string_greater_strided_loop(PyArrayMethod_Context *context, char *const data[],
                 }
             }
         }
-        if (strcmp(s1->buf, s2->buf) > 0) {
+        if (sscmp(s1, s2) > 0) {
             *out = (npy_bool)1;
         }
         else {
@@ -571,7 +569,7 @@ string_greater_equal_strided_loop(PyArrayMethod_Context *context,
                 }
             }
         }
-        if (strcmp(s1->buf, s2->buf) >= 0) {
+        if (sscmp(s1, s2) >= 0) {
             *out = (npy_bool)1;
         }
         else {
@@ -632,7 +630,7 @@ string_less_strided_loop(PyArrayMethod_Context *context, char *const data[],
                 }
             }
         }
-        if (strcmp(s1->buf, s2->buf) < 0) {
+        if (sscmp(s1, s2) < 0) {
             *out = (npy_bool)1;
         }
         else {
@@ -694,7 +692,7 @@ string_less_equal_strided_loop(PyArrayMethod_Context *context,
                 }
             }
         }
-        if (strcmp(s1->buf, s2->buf) <= 0) {
+        if (sscmp(s1, s2) <= 0) {
             *out = (npy_bool)1;
         }
         else {

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -717,3 +717,10 @@ def test_datetime_cast(dtype):
         a = np.delete(a, 3)
 
     np.testing.assert_array_equal(sa, a.astype("U"))
+
+
+def test_null_roundtripping(dtype):
+    data = ["hello\0world", "ABC\0DEF\0\0"]
+    arr = np.array(data, dtype=dtype)
+    assert data[0] == arr[0]
+    assert data[1] == arr[1]


### PR DESCRIPTION
ping @WarrenWeckesser @mhvk who suggested this in the NEP discussion

Thankfully the changes were straightforward.

I added a wrapper for `strncmp` to the static string API since `strcmp` is a no-go now.

Thankfully all the places I was passing null-terminated strings in the CPython C API have alternatives where I don't need a null-terminated string. The only slight unpleasantness is I had to create a temporary python string in the string to int cast where I could avoid that before.