### PR TITLE
Use PyMem allocators

### DIFF
--- a/asciidtype/tests/test_asciidtype.py
+++ b/asciidtype/tests/test_asciidtype.py
@@ -157,7 +157,7 @@ def test_casting_safety():
 def test_unicode_to_ascii_to_unicode():
     arr = np.array(["hello", "this", "is", "an", "array"])
     ascii_arr = arr.astype(ASCIIDType(5))
-    for dtype in ["U5", np.unicode_, np.str_]:
+    for dtype in ["U5", np.str_]:
         round_trip_arr = ascii_arr.astype(dtype)
         np.testing.assert_array_equal(arr, round_trip_arr)
 

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -1171,7 +1171,7 @@ get_cast_spec(const char *name, NPY_CASTING casting,
               NPY_ARRAYMETHOD_FLAGS flags, PyArray_DTypeMeta **dtypes,
               PyType_Slot *slots)
 {
-    PyArrayMethod_Spec *ret = malloc(sizeof(PyArrayMethod_Spec));
+    PyArrayMethod_Spec *ret = PyMem_Malloc(sizeof(PyArrayMethod_Spec));
 
     ret->name = name;
     ret->nin = 1;
@@ -1187,7 +1187,7 @@ get_cast_spec(const char *name, NPY_CASTING casting,
 PyArray_DTypeMeta **
 get_dtypes(PyArray_DTypeMeta *dt1, PyArray_DTypeMeta *dt2)
 {
-    PyArray_DTypeMeta **ret = malloc(2 * sizeof(PyArray_DTypeMeta *));
+    PyArray_DTypeMeta **ret = PyMem_Malloc(2 * sizeof(PyArray_DTypeMeta *));
 
     ret[0] = dt1;
     ret[1] = dt2;
@@ -1297,7 +1297,7 @@ get_casts()
             dt2s_dtypes, dt2s_slots);
 
     PyArrayMethod_Spec **casts =
-            malloc((num_casts + 1) * sizeof(PyArrayMethod_Spec *));
+            PyMem_Malloc((num_casts + 1) * sizeof(PyArrayMethod_Spec *));
 
     int cast_i = 0;
 

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -788,9 +788,11 @@ init_string_dtype(void)
     StringDType.base.singleton = singleton;
 
     for (int i = 0; StringDType_casts[i] != NULL; i++) {
-        free(StringDType_casts[i]->dtypes);
-        free(StringDType_casts[i]);
+        PyMem_Free(StringDType_casts[i]->dtypes);
+        PyMem_Free(StringDType_casts[i]);
     }
+
+    PyMem_Free(StringDType_casts);
 
     return 0;
 }

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -1,3 +1,5 @@
+#include "Python.h"
+
 #include "static_string.h"
 
 // defined this way so it has an in-memory representation that is distinct
@@ -16,7 +18,7 @@ ssnewlen(const char *init, size_t len, ss *to_init)
         return 0;
     }
 
-    char *ret_buf = (char *)malloc(sizeof(char) * len);
+    char *ret_buf = (char *)PyMem_RawMalloc(sizeof(char) * len);
 
     if (ret_buf == NULL) {
         return -1;
@@ -35,7 +37,7 @@ void
 ssfree(ss *str)
 {
     if (str->buf != NULL && str->buf != EMPTY_STRING.buf) {
-        free(str->buf);
+        PyMem_RawFree(str->buf);
         str->buf = NULL;
     }
     str->len = 0;
@@ -68,7 +70,7 @@ ssnewemptylen(size_t num_bytes, ss *out)
         return 0;
     }
 
-    char *buf = (char *)malloc(sizeof(char) * num_bytes);
+    char *buf = (char *)PyMem_RawMalloc(sizeof(char) * num_bytes);
 
     if (buf == NULL) {
         return -1;

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -22,9 +22,10 @@ ssnewlen(const char *init, size_t len, ss *to_init);
 void
 ssfree(ss *str);
 
-// copies the contents out *in* into *out*. Allocates a new string buffer for
-// *out*. Returns -1 if malloc fails and -2 if *out* is not empty. Returns 0 on
-// success.
+// Copies the contents of *in* into *out*. Allocates a new string buffer for
+// *out* and assumes that *out* is uninitialized. Returns -1 if malloc fails
+// and -2 if *out* is not initialized. ssfree *must* be called before this is
+// called if *in* points to an existing string. Returns 0 on success.
 int
 ssdup(const ss *in, ss *out);
 

--- a/stringdtype/tests/test_char.py
+++ b/stringdtype/tests/test_char.py
@@ -14,7 +14,7 @@ def string_array():
 
 @pytest.fixture
 def unicode_array():
-    return np.array(TEST_DATA, dtype=np.unicode_)
+    return np.array(TEST_DATA, dtype=np.str_)
 
 
 UNARY_FUNCTIONS = [

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -145,7 +145,7 @@ def test_scalars_string_conversion(data, dtype):
     ],
 )
 def test_unicode_casts(dtype, strings):
-    arr = np.array(strings, dtype=np.unicode_).astype(dtype)
+    arr = np.array(strings, dtype=np.str_).astype(dtype)
     expected = np.array(strings, dtype=dtype)
     np.testing.assert_array_equal(arr, expected)
 


### PR DESCRIPTION
This refactors the dtype to use the PyMem allocators. This gives us allocation tracking via tracemalloc for free:

```
$  cat -n test-tracemalloc.py 
     1	from stringdtype import StringDType
     2	import numpy as np
     3	from numpy.core._multiarray_umath import _get_sfloat_dtype
     4	
     5	import tracemalloc
     6	
     7	tracemalloc.start()
     8	
     9	data = [str(i) * 10 for i in range(100_000)]
    10	arr = np.array(data, dtype=StringDType())
    11	
    12	snapshot = tracemalloc.take_snapshot()
    13	top_stats = snapshot.statistics("lineno")
    14	
    15	print("[ Top 5 ]")
    16	for stat in top_stats[:5]:
    17	    print(stat)

$  NUMPY_EXPERIMENTAL_DTYPE_API=1 python -X tracemalloc test-tracemalloc.py
[ Top 5 ]
/home/nathan/Documents/numpy-experiments/test-tracemalloc.py:10: size=14.0 MiB, count=200003, average=73 B
/home/nathan/Documents/numpy-experiments/test-tracemalloc.py:9: size=10.1 MiB, count=100004, average=106 B
<frozen importlib._bootstrap_external>:672: size=3903 KiB, count=33040, average=121 B
<frozen importlib._bootstrap>:241: size=1591 KiB, count=13149, average=124 B
/home/nathan/.pyenv/versions/3.10.9-debug/lib/python3.10/abc.py:106: size=185 KiB, count=879, average=216 B
```

I also added a spot that was missing a `free` in `get_casts`, expanded the docstring for the `ssdup` function, and replaced `np.unicode_` with `np.str_` because of the NumPy 2.0 API changes.