### PR TITLE
Better naming of public symbols and small string optimization

### DIFF
--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -209,8 +209,8 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
         }
         npy_static_string *out_ss = (npy_static_string *)out;
         npy_string_free(out_ss);
-        if (npy_string_newemptylen(out_num_bytes, out_ss) < 0) {
-            gil_error(PyExc_MemoryError, "npy_string_newemptylen failed");
+        if (npy_string_newemptysize(out_num_bytes, out_ss) < 0) {
+            gil_error(PyExc_MemoryError, "npy_string_newemptysize failed");
             return -1;
         }
         char *out_buf = out_ss->buf;
@@ -342,16 +342,16 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
             if (has_null && !has_string_na) {
                 // lossy but not much else we can do
                 this_string = (unsigned char *)descr->na_name.buf;
-                n_bytes = descr->na_name.len;
+                n_bytes = descr->na_name.size;
             }
             else {
                 this_string = (unsigned char *)(default_string.buf);
-                n_bytes = default_string.len;
+                n_bytes = default_string.size;
             }
         }
         else {
             this_string = (unsigned char *)(s->buf);
-            n_bytes = s->len;
+            n_bytes = s->size;
         }
         size_t tot_n_bytes = 0;
 
@@ -440,10 +440,10 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
                 *out = (npy_bool)1;
             }
             else {
-                *out = (npy_bool)(default_string.len == 0);
+                *out = (npy_bool)(default_string.size == 0);
             }
         }
-        else if (s->len == 0) {
+        else if (s->size == 0) {
             *out = (npy_bool)0;
         }
         else {
@@ -482,14 +482,14 @@ bool_to_string(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
         npy_static_string *out_ss = (npy_static_string *)out;
         npy_string_free(out_ss);
         if ((npy_bool)(*in) == 1) {
-            if (npy_string_newlen("True", 4, out_ss) < 0) {
-                gil_error(PyExc_MemoryError, "npy_string_newlen failed");
+            if (npy_string_newsize("True", 4, out_ss) < 0) {
+                gil_error(PyExc_MemoryError, "npy_string_newsize failed");
                 return -1;
             }
         }
         else if ((npy_bool)(*in) == 0) {
-            if (npy_string_newlen("False", 5, out_ss) < 0) {
-                gil_error(PyExc_MemoryError, "npy_string_newlen failed");
+            if (npy_string_newsize("False", 5, out_ss) < 0) {
+                gil_error(PyExc_MemoryError, "npy_string_newsize failed");
                 return -1;
             }
         }
@@ -527,7 +527,7 @@ string_to_pylong(char *in, int hasnull)
         }
         s = &EMPTY_STRING;
     }
-    PyObject *val_obj = PyUnicode_FromStringAndSize(s->buf, s->len);
+    PyObject *val_obj = PyUnicode_FromStringAndSize(s->buf, s->size);
     if (val_obj == NULL) {
         return NULL;
     }
@@ -587,8 +587,8 @@ pyobj_to_string(PyObject *obj, char *out)
     }
     npy_static_string *out_ss = (npy_static_string *)out;
     npy_string_free(out_ss);
-    if (npy_string_newlen(cstr_val, length, out_ss) < 0) {
-        PyErr_SetString(PyExc_MemoryError, "npy_string_newlen failed");
+    if (npy_string_newsize(cstr_val, length, out_ss) < 0) {
+        PyErr_SetString(PyExc_MemoryError, "npy_string_newsize failed");
         Py_DECREF(pystr_val);
         return -1;
     }
@@ -779,7 +779,7 @@ string_to_pyfloat(char *in, int hasnull)
         }
         s = &EMPTY_STRING;
     }
-    PyObject *val_obj = PyUnicode_FromStringAndSize(s->buf, s->len);
+    PyObject *val_obj = PyUnicode_FromStringAndSize(s->buf, s->size);
     if (val_obj == NULL) {
         return NULL;
     }
@@ -1004,7 +1004,7 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
             s = &default_string;
         }
         if (NpyDatetime_ParseISO8601Datetime(
-                    (const char *)s->buf, s->len, in_unit, NPY_UNSAFE_CASTING,
+                    (const char *)s->buf, s->size, in_unit, NPY_UNSAFE_CASTING,
                     &dts, &in_meta.base, &out_special) < 0) {
             return -1;
         }
@@ -1072,9 +1072,10 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
                 return -1;
             }
 
-            if (npy_string_newlen(datetime_buf, strlen(datetime_buf), out_ss) <
-                0) {
-                PyErr_SetString(PyExc_MemoryError, "npy_string_newlen failed");
+            if (npy_string_newsize(datetime_buf, strlen(datetime_buf),
+                                   out_ss) < 0) {
+                PyErr_SetString(PyExc_MemoryError,
+                                "npy_string_newsize failed");
                 return -1;
             }
         }

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -1057,8 +1057,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
         npy_static_string *out_ss = (npy_static_string *)out;
         npy_string_free(out_ss);
         if (*in == NPY_DATETIME_NAT) {
-            /* convert to NA */
-            out_ss = NULL;
+            *out_ss = NPY_NULL_STRING;
         }
         else {
             if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(dt_meta, *in,

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -525,7 +525,7 @@ string_to_pylong(char *in, int hasnull)
                             "integers");
             return NULL;
         }
-        s = &EMPTY_STRING;
+        s = &NPY_EMPTY_STRING;
     }
     PyObject *val_obj =
             PyUnicode_FromStringAndSize(npy_string_buf(s), npy_string_size(s));
@@ -778,7 +778,7 @@ string_to_pyfloat(char *in, int hasnull)
                             "integers");
             return NULL;
         }
-        s = &EMPTY_STRING;
+        s = &NPY_EMPTY_STRING;
     }
     PyObject *val_obj =
             PyUnicode_FromStringAndSize(npy_string_buf(s), npy_string_size(s));

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -223,7 +223,6 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
             return -1;
         }
 
-        // copies contents of val into item_val->buf
         int res = npy_string_newsize(val, length, sdata);
 
         if (res == -1) {
@@ -260,8 +259,8 @@ stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
         }
     }
     else {
-        char *data = sdata->buf;
-        size_t size = sdata->size;
+        char *data = npy_string_buf(sdata);
+        size_t size = npy_string_size(sdata);
         val_obj = PyUnicode_FromStringAndSize(data, size);
         if (val_obj == NULL) {
             return NULL;
@@ -287,7 +286,7 @@ stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
 npy_bool
 nonzero(void *data, void *NPY_UNUSED(arr))
 {
-    return ((npy_static_string *)data)->size != 0;
+    return npy_string_size((npy_static_string *)data) != 0;
 }
 
 // Implementation of PyArray_CompareFunc.

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -582,6 +582,8 @@ static void
 stringdtype_dealloc(StringDTypeObject *self)
 {
     Py_XDECREF(self->na_object);
+    npy_string_free(&self->packed_default_string);
+    npy_string_free(&self->packed_na_name);
     PyArrayDescr_Type.tp_dealloc((PyObject *)self);
 }
 

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -32,7 +32,7 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
             Py_ssize_t size = 0;
             const char *buf = PyUnicode_AsUTF8AndSize(na_object, &size);
             default_string = NULL_STRING;
-            int res = npy_string_newlen(buf, (size_t)size, &default_string);
+            int res = npy_string_newsize(buf, (size_t)size, &default_string);
             if (res == -1) {
                 PyErr_NoMemory();
                 Py_DECREF(new);
@@ -72,7 +72,7 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
 
         Py_ssize_t size = 0;
         const char *utf8_ptr = PyUnicode_AsUTF8AndSize(na_pystr, &size);
-        int res = npy_string_newlen(utf8_ptr, (size_t)size, &na_name);
+        int res = npy_string_newsize(utf8_ptr, (size_t)size, &na_name);
         if (res == -1) {
             PyErr_NoMemory();
             Py_DECREF(new);
@@ -224,7 +224,7 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
         }
 
         // copies contents of val into item_val->buf
-        int res = npy_string_newlen(val, length, sdata);
+        int res = npy_string_newsize(val, length, sdata);
 
         if (res == -1) {
             PyErr_NoMemory();
@@ -261,8 +261,8 @@ stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
     }
     else {
         char *data = sdata->buf;
-        size_t len = sdata->len;
-        val_obj = PyUnicode_FromStringAndSize(data, len);
+        size_t size = sdata->size;
+        val_obj = PyUnicode_FromStringAndSize(data, size);
         if (val_obj == NULL) {
             return NULL;
         }
@@ -287,7 +287,7 @@ stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
 npy_bool
 nonzero(void *data, void *NPY_UNUSED(arr))
 {
-    return ((npy_static_string *)data)->len != 0;
+    return ((npy_static_string *)data)->size != 0;
 }
 
 // Implementation of PyArray_CompareFunc.
@@ -421,7 +421,7 @@ stringdtype_fill_zero_loop(void *NPY_UNUSED(traverse_context),
                            NpyAuxData *NPY_UNUSED(auxdata))
 {
     while (size--) {
-        if (npy_string_newlen("", 0, (npy_static_string *)(data)) < 0) {
+        if (npy_string_newsize("", 0, (npy_static_string *)(data)) < 0) {
             return -1;
         }
         data += stride;

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -20,18 +20,18 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
 
     Py_XINCREF(na_object);
     ((StringDTypeObject *)new)->na_object = na_object;
-    npy_static_string na_name = NULL_STRING;
+    npy_static_string na_name = NPY_NULL_STRING;
     int hasnull = na_object != NULL;
     int has_nan_na = 0;
     int has_string_na = 0;
-    npy_static_string default_string = EMPTY_STRING;
+    npy_static_string default_string = NPY_EMPTY_STRING;
     if (hasnull) {
         // first check for a string
         if (PyUnicode_Check(na_object)) {
             has_string_na = 1;
             Py_ssize_t size = 0;
             const char *buf = PyUnicode_AsUTF8AndSize(na_object, &size);
-            default_string = NULL_STRING;
+            default_string = NPY_NULL_STRING;
             int res = npy_string_newsize(buf, (size_t)size, &default_string);
             if (res == -1) {
                 PyErr_NoMemory();

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -25,8 +25,8 @@ typedef struct {
     int coerce;
     int has_nan_na;
     int has_string_na;
-    ss default_string;
-    ss na_name;
+    npy_static_string default_string;
+    npy_static_string na_name;
 } StringDTypeObject;
 
 typedef struct {

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -26,6 +26,7 @@ typedef struct {
     int has_nan_na;
     int has_string_na;
     ss default_string;
+    ss na_name;
 } StringDTypeObject;
 
 typedef struct {

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -26,7 +26,9 @@ typedef struct {
     int has_nan_na;
     int has_string_na;
     npy_static_string default_string;
+    npy_packed_static_string packed_default_string;
     npy_static_string na_name;
+    npy_packed_static_string packed_na_name;
 } StringDTypeObject;
 
 typedef struct {

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -58,7 +58,7 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
         npy_intp count = *innersizeptr;
 
         while (count--) {
-            memory_usage += ((npy_static_string *)in)->len;
+            memory_usage += ((npy_static_string *)in)->size;
             in += stride;
         }
 

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -58,7 +58,7 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
         npy_intp count = *innersizeptr;
 
         while (count--) {
-            size_t size = npy_string_size(((npy_static_string *)in));
+            size_t size = npy_string_size(((npy_packed_static_string *)in));
             if (size > NPY_SHORT_STRING_MAX_SIZE) {
                 memory_usage += size;
             }
@@ -77,7 +77,7 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
 static PyMethodDef string_methods[] = {
         {"_memory_usage", _memory_usage, METH_O,
          "get memory usage for an array"},
-        {NULL},
+        {NULL, NULL, 0, NULL},
 };
 
 static struct PyModuleDef moduledef = {

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -58,7 +58,10 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
         npy_intp count = *innersizeptr;
 
         while (count--) {
-            memory_usage += npy_string_size(((npy_static_string *)in));
+            size_t size = npy_string_size(((npy_static_string *)in));
+            if (size > NPY_SHORT_STRING_MAX_SIZE) {
+                memory_usage += size;
+            }
             in += stride;
         }
 

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -58,8 +58,7 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
         npy_intp count = *innersizeptr;
 
         while (count--) {
-            // +1 byte for the null terminator
-            memory_usage += ((ss *)in)->len + 1;
+            memory_usage += ((npy_static_string *)in)->len;
             in += stride;
         }
 

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -59,7 +59,8 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
 
         while (count--) {
             size_t size = npy_string_size(((npy_packed_static_string *)in));
-            if (size > NPY_SHORT_STRING_MAX_SIZE) {
+            // FIXME: add a way for a string to report its heap size usage
+            if (size > (sizeof(npy_static_string) - 1)) {
                 memory_usage += size;
             }
             in += stride;

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -58,7 +58,7 @@ _memory_usage(PyObject *NPY_UNUSED(self), PyObject *obj)
         npy_intp count = *innersizeptr;
 
         while (count--) {
-            memory_usage += ((npy_static_string *)in)->size;
+            memory_usage += npy_string_size(((npy_static_string *)in));
             in += stride;
         }
 

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -178,7 +178,7 @@ npy_string_free(npy_packed_static_string *str)
 {
     if (is_not_a_vstring(str)) {
         // zero out
-        memcpy(str, &NPY_EMPTY_STRING, sizeof(npy_static_string));
+        memcpy(str, NPY_EMPTY_STRING, sizeof(npy_packed_static_string));
     }
     else {
         _npy_static_string_u *str_u = (_npy_static_string_u *)str;

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -11,7 +11,8 @@ const npy_static_string NULL_STRING = {0, NULL};
 int
 npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
 {
-    if ((to_init == NULL) || (to_init->buf != NULL) || (to_init->size != 0)) {
+    if ((to_init == NULL) || (to_init->buf != NULL) ||
+        (npy_string_size(to_init) != 0)) {
         return -2;
     }
 
@@ -108,5 +109,26 @@ npy_string_isnull(const npy_static_string *in)
     if (in->size == 0 && in->buf == NULL) {
         return 1;
     }
+    return 0;
+}
+
+size_t
+npy_string_size(const npy_static_string *s)
+{
+    return s->size;
+}
+
+char *
+npy_string_buf(const npy_static_string *s)
+{
+    return s->buf;
+}
+
+int
+npy_string_size_and_buf(const npy_static_string *s, size_t *size, char **buf)
+{
+    *size = s->size;
+    *buf = s->buf;
+
     return 0;
 }

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -39,6 +39,18 @@ typedef union _npy_static_string_u {
     _short_string_buffer direct_buffer;
 } _npy_static_string_u;
 
+// room for two more flags with values 0x20 and 0x10
+#define NPY_STRING_MISSING 0x80  // 1000 0000
+#define NPY_STRING_SHORT 0x40    // 0100 0000
+
+// short string sizes fit in a 4-bit integer
+#define NPY_SHORT_STRING_SIZE_MASK 0x0F  // 0000 1111
+#define NPY_SHORT_STRING_MAX_SIZE \
+    (sizeof(npy_static_string) - 1)  // 15 or 7 depending on arch
+
+// one byte in size is reserved for flags and small string optimization
+#define NPY_MAX_STRING_SIZE (1 << (sizeof(size_t) - 1)) - 1
+
 // Since this has no flags set, technically this is a heap-allocated string
 // with size zero. Practically, that doesn't matter because we always do size
 // checks before accessing heap data, but that may be confusing. The nice part
@@ -106,7 +118,7 @@ int
 npy_string_newsize(const char *init, size_t size,
                    npy_packed_static_string *to_init)
 {
-    if (to_init == NULL || size > MAX_STRING_SIZE) {
+    if (to_init == NULL || size > NPY_MAX_STRING_SIZE) {
         return -2;
     }
 
@@ -145,7 +157,7 @@ npy_string_newsize(const char *init, size_t size,
 int
 npy_string_newemptysize(size_t size, npy_packed_static_string *out)
 {
-    if (out == NULL || size > MAX_STRING_SIZE) {
+    if (out == NULL || size > NPY_MAX_STRING_SIZE) {
         return -2;
     }
 

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -2,50 +2,120 @@
 
 #include "static_string.h"
 
+#if NPY_BYTE_ORDER == NPY_LITTLE_ENDIAN
+
+// the high byte in vstring.size is resolved for flags
+// SSSS SSSF
+
+typedef struct _npy_static_string_t {
+    char *buf;
+    size_t size;
+} _npy_static_string_t;
+
+typedef struct _short_string_buffer {
+    char buf[sizeof(_npy_static_string_t) - 1];
+    unsigned char flags_and_size;
+} _short_string_buffer;
+
+#elif NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+
+// the high byte in vstring.size is resolved for flags
+// FSSS SSSS
+
+typedef struct _npy_static_string_t {
+    size_t size;
+    char *buf;
+} _npy_static_string_t;
+
+typedef struct _short_string_buffer {
+    unsigned char flags_and_size;
+    char buf[sizeof(npy_static_string_t) - 1];
+} _short_string_buffer;
+
+#endif
+
+typedef union _npy_static_string_u {
+    _npy_static_string_t vstring;
+    _short_string_buffer direct_buffer;
+} _npy_static_string_u;
+
 // Since this has no flags set, technically this is a heap-allocated string
-// with size zero practically, that doesn't matter because we always do size
+// with size zero. Practically, that doesn't matter because we always do size
 // checks before accessing heap data, but that may be confusing. The nice part
 // of this choice is a calloc'd array buffer (e.g. from np.empty) is filled
 // with empty elements for free
-const npy_static_string NPY_EMPTY_STRING = {
-        .base = {.direct_buffer = {.flags_and_size = 0, .buf = {0}}}};
+const _npy_static_string_u empty_string_u = {
+        .direct_buffer = {.flags_and_size = 0, .buf = {0}}};
+const npy_packed_static_string *NPY_EMPTY_STRING =
+        (npy_packed_static_string *)&empty_string_u;
 // zero-filled, but with the NULL flag set to distinguish from empty string
-const npy_static_string NPY_NULL_STRING = {
-        .base = {.direct_buffer = {.flags_and_size = NPY_STRING_MISSING,
-                                   .buf = {0}}}};
+const _npy_static_string_u null_string_u = {
+        .direct_buffer = {.flags_and_size = NPY_STRING_MISSING, .buf = {0}}};
+const npy_packed_static_string *NPY_NULL_STRING =
+        (npy_packed_static_string *)&null_string_u;
 
 int
-is_short_string(const npy_static_string *s)
+is_short_string(const npy_packed_static_string *s)
 {
-    unsigned char high_byte = s->base.direct_buffer.flags_and_size;
+    unsigned char high_byte =
+            ((_npy_static_string_u *)s)->direct_buffer.flags_and_size;
     return (high_byte & NPY_STRING_SHORT) == NPY_STRING_SHORT;
 }
 
 int
-npy_string_isnull(const npy_static_string *s)
+npy_string_isnull(const npy_packed_static_string *s)
 {
-    unsigned char high_byte = s->base.direct_buffer.flags_and_size;
+    unsigned char high_byte =
+            ((_npy_static_string_u *)s)->direct_buffer.flags_and_size;
     return (high_byte & NPY_STRING_MISSING) == NPY_STRING_MISSING;
 }
 
 int
-is_not_a_vstring(const npy_static_string *s)
+is_not_a_vstring(const npy_packed_static_string *s)
 {
     return is_short_string(s) || npy_string_isnull(s);
 }
 
 int
-npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
+npy_load_string(const npy_packed_static_string *packed_string,
+                npy_static_string *unpacked_string)
 {
-    if (to_init == NULL || npy_string_size(to_init) != 0 ||
-        size > MAX_STRING_SIZE) {
+    if (npy_string_isnull(packed_string)) {
+        unpacked_string->size = 0;
+        unpacked_string->buf = NULL;
+        return 1;
+    }
+
+    _npy_static_string_u *string_u = (_npy_static_string_u *)packed_string;
+
+    if (is_short_string(packed_string)) {
+        unsigned char high_byte = string_u->direct_buffer.flags_and_size;
+        unpacked_string->size = high_byte & NPY_SHORT_STRING_SIZE_MASK;
+        unpacked_string->buf = string_u->direct_buffer.buf;
+    }
+
+    else {
+        unpacked_string->size = string_u->vstring.size;
+        unpacked_string->buf = string_u->vstring.buf;
+    }
+
+    return 0;
+}
+
+int
+npy_string_newsize(const char *init, size_t size,
+                   npy_packed_static_string *to_init)
+{
+    if (to_init == NULL || size > MAX_STRING_SIZE) {
         return -2;
     }
 
     if (size == 0) {
-        *to_init = NPY_EMPTY_STRING;
+        *to_init = *NPY_EMPTY_STRING;
         return 0;
     }
+
+    _npy_static_string_u *to_init_u = ((_npy_static_string_u *)to_init);
 
     if (size > NPY_SHORT_STRING_MAX_SIZE) {
         char *ret_buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
@@ -54,35 +124,37 @@ npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
             return -1;
         }
 
-        to_init->base.vstring.size = size;
+        to_init_u->vstring.size = size;
 
         memcpy(ret_buf, init, size);
 
-        to_init->base.vstring.buf = ret_buf;
+        to_init_u->vstring.buf = ret_buf;
     }
     else {
         // size can be no longer than 7 or 15, depending on CPU architecture
         // in either case, the size data is in at most the least significant 4
         // bits of the byte so it's safe to | with one of 0x10, 0x20, 0x40, or
         // 0x80.
-        to_init->base.direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
-        memcpy(&(to_init->base.direct_buffer.buf), init, size);
+        to_init_u->direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
+        memcpy(&(to_init_u->direct_buffer.buf), init, size);
     }
 
     return 0;
 }
 
 int
-npy_string_newemptysize(size_t size, npy_static_string *out)
+npy_string_newemptysize(size_t size, npy_packed_static_string *out)
 {
-    if (out == NULL || npy_string_size(out) != 0 || size > MAX_STRING_SIZE) {
+    if (out == NULL || size > MAX_STRING_SIZE) {
         return -2;
     }
 
     if (size == 0) {
-        *out = NPY_EMPTY_STRING;
+        *out = *NPY_EMPTY_STRING;
         return 0;
     }
+
+    _npy_static_string_u *out_u = (_npy_static_string_u *)out;
 
     if (size > NPY_SHORT_STRING_MAX_SIZE) {
         char *buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
@@ -91,61 +163,63 @@ npy_string_newemptysize(size_t size, npy_static_string *out)
             return -1;
         }
 
-        out->base.vstring.buf = buf;
-        out->base.vstring.size = size;
+        out_u->vstring.buf = buf;
+        out_u->vstring.size = size;
     }
     else {
-        out->base.direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
+        out_u->direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
     }
 
     return 0;
 }
 
 void
-npy_string_free(npy_static_string *str)
+npy_string_free(npy_packed_static_string *str)
 {
     if (is_not_a_vstring(str)) {
         // zero out
         memcpy(str, &NPY_EMPTY_STRING, sizeof(npy_static_string));
     }
     else {
-        if (str->base.vstring.size != 0) {
-            PyMem_RawFree(str->base.vstring.buf);
+        _npy_static_string_u *str_u = (_npy_static_string_u *)str;
+        if (str_u->vstring.size != 0) {
+            PyMem_RawFree(str_u->vstring.buf);
         }
-        str->base.vstring.buf = NULL;
-        str->base.vstring.size = 0;
+        str_u->vstring.buf = NULL;
+        str_u->vstring.size = 0;
     }
 }
 
 int
-npy_string_dup(const npy_static_string *in, npy_static_string *out)
+npy_string_dup(const npy_packed_static_string *in,
+               npy_packed_static_string *out)
 {
     if (npy_string_isnull(in)) {
-        *out = NPY_NULL_STRING;
+        *out = *NPY_NULL_STRING;
+        return 0;
+    }
+    if (is_short_string(in)) {
+        memcpy(out, in, sizeof(npy_packed_static_string));
         return 0;
     }
 
-    return npy_string_newsize(npy_string_buf(in), npy_string_size(in), out);
+    _npy_static_string_u *in_u = (_npy_static_string_u *)in;
+
+    return npy_string_newsize(in_u->vstring.buf, in_u->vstring.size, out);
 }
 
 int
 npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
 {
-    size_t s1_size = npy_string_size(s1);
-    size_t s2_size = npy_string_size(s2);
+    size_t minsize = s1->size < s2->size ? s1->size : s2->size;
 
-    char *s1_buf = npy_string_buf(s1);
-    char *s2_buf = npy_string_buf(s2);
-
-    size_t minsize = s1_size < s2_size ? s1_size : s2_size;
-
-    int cmp = strncmp(s1_buf, s2_buf, minsize);
+    int cmp = strncmp(s1->buf, s2->buf, minsize);
 
     if (cmp == 0) {
-        if (s1_size > minsize) {
+        if (s1->size > minsize) {
             return 1;
         }
-        if (s2_size > minsize) {
+        if (s2->size > minsize) {
             return -1;
         }
     }
@@ -154,21 +228,18 @@ npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
 }
 
 size_t
-npy_string_size(const npy_static_string *s)
+npy_string_size(const npy_packed_static_string *packed_string)
 {
-    if (is_short_string(s)) {
-        unsigned char high_byte = s->base.direct_buffer.flags_and_size;
-        return high_byte & NPY_SHORT_STRING_SIZE_MASK;
+    if (npy_string_isnull(packed_string)) {
+        return 0;
     }
-    return s->base.vstring.size;
-}
 
-char *
-npy_string_buf(const npy_static_string *s)
-{
-    if (is_short_string(s)) {
-        // the cast drops const, is there a better way?
-        return (char *)&s->base.direct_buffer.buf[0];
+    _npy_static_string_u *string_u = (_npy_static_string_u *)packed_string;
+
+    if (is_short_string(packed_string)) {
+        return string_u->direct_buffer.flags_and_size &
+               NPY_SHORT_STRING_SIZE_MASK;
     }
-    return s->base.vstring.buf;
+
+    return string_u->vstring.size;
 }

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -9,26 +9,26 @@ const npy_static_string EMPTY_STRING = {0, "\0"};
 const npy_static_string NULL_STRING = {0, NULL};
 
 int
-npy_string_newlen(const char *init, size_t len, npy_static_string *to_init)
+npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
 {
-    if ((to_init == NULL) || (to_init->buf != NULL) || (to_init->len != 0)) {
+    if ((to_init == NULL) || (to_init->buf != NULL) || (to_init->size != 0)) {
         return -2;
     }
 
-    if (len == 0) {
+    if (size == 0) {
         *to_init = EMPTY_STRING;
         return 0;
     }
 
-    char *ret_buf = (char *)PyMem_RawMalloc(sizeof(char) * len);
+    char *ret_buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
 
     if (ret_buf == NULL) {
         return -1;
     }
 
-    to_init->len = len;
+    to_init->size = size;
 
-    memcpy(ret_buf, init, len);
+    memcpy(ret_buf, init, size);
 
     to_init->buf = ret_buf;
 
@@ -42,37 +42,37 @@ npy_string_free(npy_static_string *str)
         PyMem_RawFree(str->buf);
         str->buf = NULL;
     }
-    str->len = 0;
+    str->size = 0;
 }
 
 int
 npy_string_dup(const npy_static_string *in, npy_static_string *out)
 {
     if (npy_string_isnull(in)) {
-        out->len = 0;
+        out->size = 0;
         out->buf = NULL;
         return 0;
     }
     else {
-        return npy_string_newlen(in->buf, in->len, out);
+        return npy_string_newsize(in->buf, in->size, out);
     }
 }
 
 int
-npy_string_newemptylen(size_t num_bytes, npy_static_string *out)
+npy_string_newemptysize(size_t size, npy_static_string *out)
 {
-    if (out->len != 0 || out->buf != NULL) {
+    if (out->size != 0 || out->buf != NULL) {
         return -2;
     }
 
-    out->len = num_bytes;
+    out->size = size;
 
-    if (num_bytes == 0) {
+    if (size == 0) {
         *out = EMPTY_STRING;
         return 0;
     }
 
-    char *buf = (char *)PyMem_RawMalloc(sizeof(char) * num_bytes);
+    char *buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
 
     if (buf == NULL) {
         return -1;
@@ -86,15 +86,15 @@ npy_string_newemptylen(size_t num_bytes, npy_static_string *out)
 int
 npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
 {
-    size_t minlen = s1->len < s2->len ? s1->len : s2->len;
+    size_t minsize = s1->size < s2->size ? s1->size : s2->size;
 
-    int cmp = strncmp(s1->buf, s2->buf, minlen);
+    int cmp = strncmp(s1->buf, s2->buf, minsize);
 
     if (cmp == 0) {
-        if (s1->len > minlen) {
+        if (s1->size > minsize) {
             return 1;
         }
-        if (s2->len > minlen) {
+        if (s2->size > minsize) {
             return -1;
         }
     }
@@ -105,7 +105,7 @@ npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
 int
 npy_string_isnull(const npy_static_string *in)
 {
-    if (in->len == 0 && in->buf == NULL) {
+    if (in->size == 0 && in->buf == NULL) {
         return 1;
     }
     return 0;

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -2,9 +2,11 @@
 
 #include "static_string.h"
 
-// defined this way so it has an in-memory representation that is distinct
-// from NULL, allowing us to use NULL to represent a sentinel value
+// defined this way so EMPTY_STRING has an in-memory representation that is
+// distinct from a zero-filled struct, allowing us to use a NULL_STRING
+// to represent a sentinel value
 const ss EMPTY_STRING = {0, "\0"};
+const ss NULL_STRING = {0, NULL};
 
 int
 ssnewlen(const char *init, size_t len, ss *to_init)

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -2,17 +2,43 @@
 
 #include "static_string.h"
 
-// defined this way so NPY_EMPTY_STRING has an in-memory representation that is
-// distinct from a zero-filled struct, allowing us to use a NPY_NULL_STRING
-// to represent a sentinel value
-const npy_static_string NPY_EMPTY_STRING = {0, "\0"};
-const npy_static_string NPY_NULL_STRING = {0, NULL};
+// Since this has no flags set, technically this is a heap-allocated string
+// with size zero practically, that doesn't matter because we always do size
+// checks before accessing heap data, but that may be confusing. The nice part
+// of this choice is a calloc'd array buffer (e.g. from np.empty) is filled
+// with empty elements for free
+const npy_static_string NPY_EMPTY_STRING = {
+        .base = {.direct_buffer = {.flags_and_size = 0, .buf = {0}}}};
+// zero-filled, but with the NULL flag set to distinguish from empty string
+const npy_static_string NPY_NULL_STRING = {
+        .base = {.direct_buffer = {.flags_and_size = NPY_STRING_MISSING,
+                                   .buf = {0}}}};
+
+int
+is_short_string(const npy_static_string *s)
+{
+    unsigned char high_byte = s->base.direct_buffer.flags_and_size;
+    return (high_byte & NPY_STRING_SHORT) == NPY_STRING_SHORT;
+}
+
+int
+npy_string_isnull(const npy_static_string *s)
+{
+    unsigned char high_byte = s->base.direct_buffer.flags_and_size;
+    return (high_byte & NPY_STRING_MISSING) == NPY_STRING_MISSING;
+}
+
+int
+is_not_a_vstring(const npy_static_string *s)
+{
+    return is_short_string(s) || npy_string_isnull(s);
+}
 
 int
 npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
 {
-    if ((to_init == NULL) || (to_init->buf != NULL) ||
-        (npy_string_size(to_init) != 0)) {
+    if (to_init == NULL || npy_string_size(to_init) != 0 ||
+        size > MAX_STRING_SIZE) {
         return -2;
     }
 
@@ -21,17 +47,56 @@ npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
         return 0;
     }
 
-    char *ret_buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
+    if (size > NPY_SHORT_STRING_MAX_SIZE) {
+        char *ret_buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
 
-    if (ret_buf == NULL) {
-        return -1;
+        if (ret_buf == NULL) {
+            return -1;
+        }
+
+        to_init->base.vstring.size = size;
+
+        memcpy(ret_buf, init, size);
+
+        to_init->base.vstring.buf = ret_buf;
+    }
+    else {
+        // size can be no longer than 7 or 15, depending on CPU architecture
+        // in either case, the size data is in at most the least significant 4
+        // bits of the byte so it's safe to | with one of 0x10, 0x20, 0x40, or
+        // 0x80.
+        to_init->base.direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
+        memcpy(&(to_init->base.direct_buffer.buf), init, size);
     }
 
-    to_init->size = size;
+    return 0;
+}
 
-    memcpy(ret_buf, init, size);
+int
+npy_string_newemptysize(size_t size, npy_static_string *out)
+{
+    if (out == NULL || npy_string_size(out) != 0 || size > MAX_STRING_SIZE) {
+        return -2;
+    }
 
-    to_init->buf = ret_buf;
+    if (size == 0) {
+        *out = NPY_EMPTY_STRING;
+        return 0;
+    }
+
+    if (size > NPY_SHORT_STRING_MAX_SIZE) {
+        char *buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
+
+        if (buf == NULL) {
+            return -1;
+        }
+
+        out->base.vstring.buf = buf;
+        out->base.vstring.size = size;
+    }
+    else {
+        out->base.direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
+    }
 
     return 0;
 }
@@ -39,63 +104,48 @@ npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
 void
 npy_string_free(npy_static_string *str)
 {
-    if (str->buf != NULL && str->buf != NPY_EMPTY_STRING.buf) {
-        PyMem_RawFree(str->buf);
-        str->buf = NULL;
+    if (is_not_a_vstring(str)) {
+        // zero out
+        memcpy(str, &NPY_EMPTY_STRING, sizeof(npy_static_string));
     }
-    str->size = 0;
+    else {
+        if (str->base.vstring.size != 0) {
+            PyMem_RawFree(str->base.vstring.buf);
+        }
+        str->base.vstring.buf = NULL;
+        str->base.vstring.size = 0;
+    }
 }
 
 int
 npy_string_dup(const npy_static_string *in, npy_static_string *out)
 {
     if (npy_string_isnull(in)) {
-        out->size = 0;
-        out->buf = NULL;
-        return 0;
-    }
-    else {
-        return npy_string_newsize(in->buf, in->size, out);
-    }
-}
-
-int
-npy_string_newemptysize(size_t size, npy_static_string *out)
-{
-    if (out->size != 0 || out->buf != NULL) {
-        return -2;
-    }
-
-    out->size = size;
-
-    if (size == 0) {
-        *out = NPY_EMPTY_STRING;
+        *out = NPY_NULL_STRING;
         return 0;
     }
 
-    char *buf = (char *)PyMem_RawMalloc(sizeof(char) * size);
-
-    if (buf == NULL) {
-        return -1;
-    }
-
-    out->buf = buf;
-
-    return 0;
+    return npy_string_newsize(npy_string_buf(in), npy_string_size(in), out);
 }
 
 int
 npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
 {
-    size_t minsize = s1->size < s2->size ? s1->size : s2->size;
+    size_t s1_size = npy_string_size(s1);
+    size_t s2_size = npy_string_size(s2);
 
-    int cmp = strncmp(s1->buf, s2->buf, minsize);
+    char *s1_buf = npy_string_buf(s1);
+    char *s2_buf = npy_string_buf(s2);
+
+    size_t minsize = s1_size < s2_size ? s1_size : s2_size;
+
+    int cmp = strncmp(s1_buf, s2_buf, minsize);
 
     if (cmp == 0) {
-        if (s1->size > minsize) {
+        if (s1_size > minsize) {
             return 1;
         }
-        if (s2->size > minsize) {
+        if (s2_size > minsize) {
             return -1;
         }
     }
@@ -103,32 +153,22 @@ npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
     return cmp;
 }
 
-int
-npy_string_isnull(const npy_static_string *in)
-{
-    if (in->size == 0 && in->buf == NULL) {
-        return 1;
-    }
-    return 0;
-}
-
 size_t
 npy_string_size(const npy_static_string *s)
 {
-    return s->size;
+    if (is_short_string(s)) {
+        unsigned char high_byte = s->base.direct_buffer.flags_and_size;
+        return high_byte & NPY_SHORT_STRING_SIZE_MASK;
+    }
+    return s->base.vstring.size;
 }
 
 char *
 npy_string_buf(const npy_static_string *s)
 {
-    return s->buf;
-}
-
-int
-npy_string_size_and_buf(const npy_static_string *s, size_t *size, char **buf)
-{
-    *size = s->size;
-    *buf = s->buf;
-
-    return 0;
+    if (is_short_string(s)) {
+        // the cast drops const, is there a better way?
+        return (char *)&s->base.direct_buffer.buf[0];
+    }
+    return s->base.vstring.buf;
 }

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -2,11 +2,11 @@
 
 #include "static_string.h"
 
-// defined this way so EMPTY_STRING has an in-memory representation that is
-// distinct from a zero-filled struct, allowing us to use a NULL_STRING
+// defined this way so NPY_EMPTY_STRING has an in-memory representation that is
+// distinct from a zero-filled struct, allowing us to use a NPY_NULL_STRING
 // to represent a sentinel value
-const npy_static_string EMPTY_STRING = {0, "\0"};
-const npy_static_string NULL_STRING = {0, NULL};
+const npy_static_string NPY_EMPTY_STRING = {0, "\0"};
+const npy_static_string NPY_NULL_STRING = {0, NULL};
 
 int
 npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
@@ -17,7 +17,7 @@ npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
     }
 
     if (size == 0) {
-        *to_init = EMPTY_STRING;
+        *to_init = NPY_EMPTY_STRING;
         return 0;
     }
 
@@ -39,7 +39,7 @@ npy_string_newsize(const char *init, size_t size, npy_static_string *to_init)
 void
 npy_string_free(npy_static_string *str)
 {
-    if (str->buf != NULL && str->buf != EMPTY_STRING.buf) {
+    if (str->buf != NULL && str->buf != NPY_EMPTY_STRING.buf) {
         PyMem_RawFree(str->buf);
         str->buf = NULL;
     }
@@ -69,7 +69,7 @@ npy_string_newemptysize(size_t size, npy_static_string *out)
     out->size = size;
 
     if (size == 0) {
-        *out = EMPTY_STRING;
+        *out = NPY_EMPTY_STRING;
         return 0;
     }
 

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -5,11 +5,11 @@
 // defined this way so EMPTY_STRING has an in-memory representation that is
 // distinct from a zero-filled struct, allowing us to use a NULL_STRING
 // to represent a sentinel value
-const ss EMPTY_STRING = {0, "\0"};
-const ss NULL_STRING = {0, NULL};
+const npy_static_string EMPTY_STRING = {0, "\0"};
+const npy_static_string NULL_STRING = {0, NULL};
 
 int
-ssnewlen(const char *init, size_t len, ss *to_init)
+npy_string_newlen(const char *init, size_t len, npy_static_string *to_init)
 {
     if ((to_init == NULL) || (to_init->buf != NULL) || (to_init->len != 0)) {
         return -2;
@@ -36,7 +36,7 @@ ssnewlen(const char *init, size_t len, ss *to_init)
 }
 
 void
-ssfree(ss *str)
+npy_string_free(npy_static_string *str)
 {
     if (str->buf != NULL && str->buf != EMPTY_STRING.buf) {
         PyMem_RawFree(str->buf);
@@ -46,20 +46,20 @@ ssfree(ss *str)
 }
 
 int
-ssdup(const ss *in, ss *out)
+npy_string_dup(const npy_static_string *in, npy_static_string *out)
 {
-    if (ss_isnull(in)) {
+    if (npy_string_isnull(in)) {
         out->len = 0;
         out->buf = NULL;
         return 0;
     }
     else {
-        return ssnewlen(in->buf, in->len, out);
+        return npy_string_newlen(in->buf, in->len, out);
     }
 }
 
 int
-ssnewemptylen(size_t num_bytes, ss *out)
+npy_string_newemptylen(size_t num_bytes, npy_static_string *out)
 {
     if (out->len != 0 || out->buf != NULL) {
         return -2;
@@ -83,9 +83,8 @@ ssnewemptylen(size_t num_bytes, ss *out)
     return 0;
 }
 
-// same semantics as strcmp
 int
-sscmp(const ss *s1, const ss *s2)
+npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
 {
     size_t minlen = s1->len < s2->len ? s1->len : s2->len;
 
@@ -104,7 +103,7 @@ sscmp(const ss *s1, const ss *s2)
 }
 
 int
-ss_isnull(const ss *in)
+npy_string_isnull(const npy_static_string *in)
 {
     if (in->len == 0 && in->buf == NULL) {
         return 1;

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -5,7 +5,7 @@
 #include "string.h"
 
 typedef struct npy_static_string {
-    size_t len;
+    size_t size;
     char *buf;
 } npy_static_string;
 
@@ -18,10 +18,11 @@ extern const npy_static_string EMPTY_STRING;
 extern const npy_static_string NULL_STRING;
 
 // Allocates a new buffer for *to_init*, filling with the copied contents of
-// *init* and sets *to_init->len* to *len*. Returns -1 if malloc fails and -2
-// if *to_init* is not empty. Returns 0 on success.
+// the first *size*entries in *init*, which must be valid and initialized
+// beforehand, and sets *to_init->size* to *size*. Returns -1 if malloc fails
+// and -2 if *to_init* is not NULL. Returns 0 on success.
 int
-npy_string_newlen(const char *init, size_t len, npy_static_string *to_init);
+npy_string_newsize(const char *init, size_t size, npy_static_string *to_init);
 
 // Sets len to 0 and if str->buf is not already NULL, frees it and sets it to
 // NULL. Cannot fail.
@@ -36,12 +37,11 @@ int
 npy_string_dup(const npy_static_string *in, npy_static_string *out);
 
 // Allocates a new string buffer for *out* with enough capacity to store
-// *num_bytes* of text. The actual allocation is num_bytes + 1 bytes, to
-// account for the null terminator. Does not do any initialization, the caller
-// must initialize and null-terminate the string buffer. Returns -1 if malloc
-// fails and -2 if *out* is not empty. Returns 0 on success.
+// *size* bytes of text. Does not do any initialization, the caller must
+// initialize the string buffer. Returns -1 if malloc fails and -2 if *out* is
+// not NULL. Returns 0 on success.
 int
-npy_string_newemptylen(size_t num_bytes, npy_static_string *out);
+npy_string_newemptysize(size_t size, npy_static_string *out);
 
 // Determine if *in* corresponds to a NULL npy_static_string struct (e.g. len
 // is zero and buf is NULL. Returns 1 if this is the case and zero otherwise.

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -11,11 +11,11 @@ typedef struct npy_static_string {
 
 // represents the empty string and can be passed safely to npy_static_string
 // API functions
-extern const npy_static_string EMPTY_STRING;
+extern const npy_static_string NPY_EMPTY_STRING;
 // represents a sentinel value, *CANNOT* be passed safely to npy_static_string
 // API functions, use npy_string_isnull to check if a value is null before
 // working with it.
-extern const npy_static_string NULL_STRING;
+extern const npy_static_string NPY_NULL_STRING;
 
 // Allocates a new buffer for *to_init*, which must be set to NULL before
 // calling this function, filling the newly allocated buffer with the copied

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -17,15 +17,18 @@ extern const npy_static_string EMPTY_STRING;
 // working with it.
 extern const npy_static_string NULL_STRING;
 
-// Allocates a new buffer for *to_init*, filling with the copied contents of
-// the first *size*entries in *init*, which must be valid and initialized
-// beforehand, and sets *to_init->size* to *size*. Returns -1 if malloc fails
-// and -2 if *to_init* is not NULL. Returns 0 on success.
+// Allocates a new buffer for *to_init*, which must be set to NULL before
+// calling this function, filling the newly allocated buffer with the copied
+// contents of the first *size* entries in *init*, which must be valid and
+// initialized beforehand. Calling npy_string_free on *to_init* before calling
+// this function on an existing string is sufficient to initialize it. Returns
+// -1 if malloc fails and -2 if the internal buffer in *to_init* is not NULL
+// to indicate a programming error. Returns 0 on success.
 int
 npy_string_newsize(const char *init, size_t size, npy_static_string *to_init);
 
-// Sets len to 0 and if str->buf is not already NULL, frees it and sets it to
-// NULL. Cannot fail.
+// Sets len to 0 and if the internal buffer is not already NULL, frees it if
+// it is allocated on the heap and sets it to NULL. Cannot fail.
 void
 npy_string_free(npy_static_string *str);
 
@@ -53,5 +56,18 @@ npy_string_isnull(const npy_static_string *in);
 // null-terminated C strings with the content of *s1* and *s2*.
 int
 npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2);
+
+// Returns the *size* of *s*
+size_t
+npy_string_size(const npy_static_string *s);
+
+// Returns the string *buf* of *s*. This is not a null-terminated buffer.
+char *
+npy_string_buf(const npy_static_string *s);
+
+// Fills in *size* and *buf* pointers with the values in *s*.
+// Currently always returns 0.
+int
+npy_string_size_and_buf(const npy_static_string *s, size_t *size, char **buf);
 
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -9,7 +9,11 @@ typedef struct ss {
     char *buf;
 } ss;
 
+// represents the empty string and can be passed safely to ss API functions
 extern const ss EMPTY_STRING;
+// represents a sentinel value, *CANNOT* be passed safely to ss API functions,
+// use ss_isnull to check if a value is null before working with it.
+extern const ss NULL_STRING;
 
 // Allocates a new buffer for *to_init*, filling with the copied contents of
 // *init* and sets *to_init->len* to *len*. Returns -1 if malloc fails and -2

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -13,18 +13,6 @@ typedef struct npy_static_string {
     const char *buf;
 } npy_static_string;
 
-// room for two more flags with values 0x20 and 0x10
-#define NPY_STRING_MISSING 0x80  // 1000 0000
-#define NPY_STRING_SHORT 0x40    // 0100 0000
-
-// short string sizes fit in a 4-bit integer
-#define NPY_SHORT_STRING_SIZE_MASK 0x0F  // 0000 1111
-#define NPY_SHORT_STRING_MAX_SIZE \
-    (sizeof(npy_static_string) - 1)  // 15 or 7 depending on arch
-
-// one byte in size is reserved for flags and small string optimization
-#define MAX_STRING_SIZE (1 << (sizeof(size_t) - 1)) - 1
-
 // represents the empty string and can be passed safely to npy_static_string
 // API functions
 extern const npy_packed_static_string *NPY_EMPTY_STRING;

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -4,45 +4,13 @@
 #include "stdlib.h"
 #include "string.h"
 
-#if NPY_BYTE_ORDER == NPY_LITTLE_ENDIAN
-
-// the high byte in vstring.size is resolved for flags
-// SSSS SSSF
-
-typedef struct _npy_static_string_t {
-    char *buf;
-    size_t size;
-} _npy_static_string_t;
-
-typedef struct _short_string_buffer {
-    char buf[sizeof(_npy_static_string_t) - 1];
-    unsigned char flags_and_size;
-} _short_string_buffer;
-
-#elif NPY_BYTE_ORDER == NPY_BIG_ENDIAN
-
-// the high byte in vstring.size is resolved for flags
-// FSSS SSSS
-
-typedef struct _npy_static_string_t {
-    size_t size;
-    char *buf;
-} _npy_static_string_t;
-
-typedef struct _short_string_buffer {
-    unsigned char flags_and_size;
-    char buf[sizeof(npy_static_string_t) - 1];
-} _short_string_buffer;
-
-#endif
-
-typedef union _npy_static_string_u {
-    _npy_static_string_t vstring;
-    _short_string_buffer direct_buffer;
-} _npy_static_string_u;
+typedef struct npy_packed_static_string {
+    char packed_buffer[sizeof(char *) + sizeof(size_t)];
+} npy_packed_static_string;
 
 typedef struct npy_static_string {
-    _npy_static_string_u base;
+    size_t size;
+    const char *buf;
 } npy_static_string;
 
 // room for two more flags with values 0x20 and 0x10
@@ -59,11 +27,11 @@ typedef struct npy_static_string {
 
 // represents the empty string and can be passed safely to npy_static_string
 // API functions
-extern const npy_static_string NPY_EMPTY_STRING;
+extern const npy_packed_static_string *NPY_EMPTY_STRING;
 // represents a sentinel value, *CANNOT* be passed safely to npy_static_string
 // API functions, use npy_string_isnull to check if a value is null before
 // working with it.
-extern const npy_static_string NPY_NULL_STRING;
+extern const npy_packed_static_string *NPY_NULL_STRING;
 
 // Allocates a new buffer for *to_init*, which must be set to NULL before
 // calling this function, filling the newly allocated buffer with the copied
@@ -73,44 +41,45 @@ extern const npy_static_string NPY_NULL_STRING;
 // -1 if malloc fails and -2 if the internal buffer in *to_init* is not NULL
 // to indicate a programming error. Returns 0 on success.
 int
-npy_string_newsize(const char *init, size_t size, npy_static_string *to_init);
+npy_string_newsize(const char *init, size_t size,
+                   npy_packed_static_string *to_init);
 
 // Sets len to 0 and if the internal buffer is not already NULL, frees it if
 // it is allocated on the heap and sets it to NULL. Cannot fail.
 void
-npy_string_free(npy_static_string *str);
+npy_string_free(npy_packed_static_string *str);
 
 // Copies the contents of *in* into *out*. Allocates a new string buffer for
 // *out* and assumes that *out* is uninitialized. Returns -1 if malloc fails
 // and -2 if *out* is not initialized. npy_string_free *must* be called before
 // this is called if *in* points to an existing string. Returns 0 on success.
 int
-npy_string_dup(const npy_static_string *in, npy_static_string *out);
+npy_string_dup(const npy_packed_static_string *in,
+               npy_packed_static_string *out);
 
 // Allocates a new string buffer for *out* with enough capacity to store
 // *size* bytes of text. Does not do any initialization, the caller must
 // initialize the string buffer. Returns -1 if malloc fails and -2 if *out* is
 // not NULL. Returns 0 on success.
 int
-npy_string_newemptysize(size_t size, npy_static_string *out);
+npy_string_newemptysize(size_t size, npy_packed_static_string *out);
 
 // Determine if *in* corresponds to a NULL npy_static_string struct (e.g. len
 // is zero and buf is NULL. Returns 1 if this is the case and zero otherwise.
 // Cannot fail.
 int
-npy_string_isnull(const npy_static_string *in);
+npy_string_isnull(const npy_packed_static_string *in);
 
-// Compare two strings. Has the same sematics as if strcmp were passed
+// Compare two strings. Has the same semantics as if strcmp were passed
 // null-terminated C strings with the content of *s1* and *s2*.
 int
 npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2);
 
-// Returns the *size* of *s*
-size_t
-npy_string_size(const npy_static_string *s);
+int
+npy_load_string(const npy_packed_static_string *packed_string,
+                npy_static_string *unpacked_string);
 
-// Returns the string *buf* of *s*. This is not a null-terminated buffer.
-char *
-npy_string_buf(const npy_static_string *s);
+size_t
+npy_string_size(const npy_packed_static_string *packed_string);
 
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -4,34 +4,36 @@
 #include "stdlib.h"
 #include "string.h"
 
-typedef struct ss {
+typedef struct npy_static_string {
     size_t len;
     char *buf;
-} ss;
+} npy_static_string;
 
-// represents the empty string and can be passed safely to ss API functions
-extern const ss EMPTY_STRING;
-// represents a sentinel value, *CANNOT* be passed safely to ss API functions,
-// use ss_isnull to check if a value is null before working with it.
-extern const ss NULL_STRING;
+// represents the empty string and can be passed safely to npy_static_string
+// API functions
+extern const npy_static_string EMPTY_STRING;
+// represents a sentinel value, *CANNOT* be passed safely to npy_static_string
+// API functions, use npy_string_isnull to check if a value is null before
+// working with it.
+extern const npy_static_string NULL_STRING;
 
 // Allocates a new buffer for *to_init*, filling with the copied contents of
 // *init* and sets *to_init->len* to *len*. Returns -1 if malloc fails and -2
 // if *to_init* is not empty. Returns 0 on success.
 int
-ssnewlen(const char *init, size_t len, ss *to_init);
+npy_string_newlen(const char *init, size_t len, npy_static_string *to_init);
 
 // Sets len to 0 and if str->buf is not already NULL, frees it and sets it to
 // NULL. Cannot fail.
 void
-ssfree(ss *str);
+npy_string_free(npy_static_string *str);
 
 // Copies the contents of *in* into *out*. Allocates a new string buffer for
 // *out* and assumes that *out* is uninitialized. Returns -1 if malloc fails
-// and -2 if *out* is not initialized. ssfree *must* be called before this is
-// called if *in* points to an existing string. Returns 0 on success.
+// and -2 if *out* is not initialized. npy_string_free *must* be called before
+// this is called if *in* points to an existing string. Returns 0 on success.
 int
-ssdup(const ss *in, ss *out);
+npy_string_dup(const npy_static_string *in, npy_static_string *out);
 
 // Allocates a new string buffer for *out* with enough capacity to store
 // *num_bytes* of text. The actual allocation is num_bytes + 1 bytes, to
@@ -39,16 +41,17 @@ ssdup(const ss *in, ss *out);
 // must initialize and null-terminate the string buffer. Returns -1 if malloc
 // fails and -2 if *out* is not empty. Returns 0 on success.
 int
-ssnewemptylen(size_t num_bytes, ss *out);
+npy_string_newemptylen(size_t num_bytes, npy_static_string *out);
 
-// Determine if *in* corresponds to a NULL ss struct (e.g. len is zero and buf
-// is NULL. Returns 1 if this is the case and zero otherwise. Cannot fail.
+// Determine if *in* corresponds to a NULL npy_static_string struct (e.g. len
+// is zero and buf is NULL. Returns 1 if this is the case and zero otherwise.
+// Cannot fail.
 int
-ss_isnull(const ss *in);
+npy_string_isnull(const npy_static_string *in);
 
-// Compare two strings. Has the same sematics as strcmp passed null-terminated
-// C strings with the content of *s1* and *s2*.
+// Compare two strings. Has the same sematics as if strcmp were passed
+// null-terminated C strings with the content of *s1* and *s2*.
 int
-sscmp(const ss *s1, const ss *s2);
+npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2);
 
 #endif /*_NPY_STATIC_STRING_H */

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -67,16 +67,16 @@ multiply_resolve_descriptors(
                 }                                                             \
             }                                                                 \
             npy_##shortname factor = *(npy_##shortname *)iin;                 \
-            size_t newlen = (size_t)((is->len) * factor);                     \
+            size_t newsize = (size_t)((is->size) * factor);                   \
                                                                               \
-            if (npy_string_newemptylen(newlen, os) < 0) {                     \
+            if (npy_string_newemptysize(newsize, os) < 0) {                   \
                 gil_error(PyExc_MemoryError,                                  \
-                          "npy_string_newemptylen failed");                   \
+                          "npy_string_newemptysize failed");                  \
                 return -1;                                                    \
             }                                                                 \
                                                                               \
             for (size_t i = 0; i < (size_t)factor; i++) {                     \
-                memcpy(os->buf + i * is->len, is->buf, is->len);              \
+                memcpy(os->buf + i * is->size, is->buf, is->size);            \
             }                                                                 \
                                                                               \
             sin += s_stride;                                                  \
@@ -215,7 +215,7 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
     npy_static_string *os = NULL;
 
     while (N--) {
-        int newlen = 0;
+        int newsize = 0;
         s1 = (npy_static_string *)in1;
         s2 = (npy_static_string *)in2;
         int s1_isnull = npy_string_isnull(s1);
@@ -240,13 +240,13 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
                           "Cannot add null that is not a nan-like value");
             }
         }
-        newlen = s1->len + s2->len;
-        if (npy_string_newemptylen(newlen, os) < 0) {
+        newsize = s1->size + s2->size;
+        if (npy_string_newemptysize(newsize, os) < 0) {
             return -1;
         }
 
-        memcpy(os->buf, s1->buf, s1->len);
-        memcpy(os->buf + s1->len, s2->buf, s2->len);
+        memcpy(os->buf, s1->buf, s1->size);
+        memcpy(os->buf + s1->size, s2->buf, s2->size);
 
     next_step:
         in1 += in1_stride;
@@ -385,7 +385,7 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
                 }
             }
         }
-        if (s1->len == s2->len && strncmp(s1->buf, s2->buf, s1->len) == 0) {
+        if (s1->size == s2->size && strncmp(s1->buf, s2->buf, s1->size) == 0) {
             *out = (npy_bool)1;
         }
         else {
@@ -450,7 +450,7 @@ string_not_equal_strided_loop(PyArrayMethod_Context *context,
                 }
             }
         }
-        if (s1->len == s2->len && strncmp(s1->buf, s2->buf, s1->len) == 0) {
+        if (s1->size == s2->size && strncmp(s1->buf, s2->buf, s1->size) == 0) {
             *out = (npy_bool)0;
         }
         else {

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -260,11 +260,10 @@ def test_isnan(dtype, string_list):
 
 def test_memory_usage(dtype):
     sarr = np.array(["abc", "def", "ghi"], dtype=dtype)
-    # 4 bytes for each ASCII string buffer in string_list
-    # (three characters and null terminator)
+    # 3 bytes for each ASCII string buffer in string_list
     # plus enough bytes for the size_t length
     # plus enough bytes for the pointer in the array buffer
-    assert _memory_usage(sarr) == (4 + 2 * np.dtype(np.uintp).itemsize) * 3
+    assert _memory_usage(sarr) == (3 + 2 * np.dtype(np.uintp).itemsize) * 3
     with pytest.raises(TypeError):
         _memory_usage("hello")
     with pytest.raises(TypeError):

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -259,11 +259,11 @@ def test_isnan(dtype, string_list):
 
 
 def test_memory_usage(dtype):
-    sarr = np.array(["abc", "def", "ghi"], dtype=dtype)
-    # 3 bytes for each ASCII string buffer in string_list
+    sarr = np.array(["abcdefghijklmnopqrstuvqxyz", "def", "ghi"], dtype=dtype)
+    # 26 bytes for the long string buffer in string_list
     # plus enough bytes for the size_t length
     # plus enough bytes for the pointer in the array buffer
-    assert _memory_usage(sarr) == (3 + 2 * np.dtype(np.uintp).itemsize) * 3
+    assert _memory_usage(sarr) == (2 * np.dtype(np.uintp).itemsize) * 3 + 26
     with pytest.raises(TypeError):
         _memory_usage("hello")
     with pytest.raises(TypeError):
@@ -366,33 +366,10 @@ def test_nonzero(dtype, strings):
 
 def test_creation_functions(dtype):
     np.testing.assert_array_equal(np.zeros(3, dtype=dtype), ["", "", ""])
+    np.testing.assert_array_equal(np.empty(3, dtype=dtype), ["", "", ""])
 
     assert np.zeros(3, dtype=dtype)[0] == ""
-
-    has_null = hasattr(dtype, "na_object")
-    if has_null:
-        is_nan = isinstance(dtype.na_object, float) and np.isnan(
-            dtype.na_object
-        )
-        bool_errors = False
-        try:
-            bool(dtype.na_object)
-        except TypeError:
-            bool_errors = True
-    else:
-        is_nan = False
-        bool_errors = False
-
-    if is_nan or bool_errors:
-        assert np.all(np.isnan(np.empty(3, dtype=dtype)))
-        assert np.empty(3, dtype=dtype)[0] is dtype.na_object
-    elif hasattr(dtype, "na_object"):
-        res = [dtype.na_object] * 3
-        np.testing.assert_array_equal(np.empty(3, dtype=dtype), res)
-        assert np.empty(3, dtype=dtype)[0] == dtype.na_object
-    else:
-        np.testing.assert_array_equal(np.empty(3, dtype=dtype), ["", "", ""])
-        assert np.empty(3, dtype=dtype)[0] == ""
+    assert np.empty(3, dtype=dtype)[0] == ""
 
 
 def test_is_numeric(dtype):


### PR DESCRIPTION
This refactors things to better match the naming scheme in the NEP. 

It also adds small string optimization following @WarrenWeckesser's prototype. 

I first refactored everything outside the implementation of the string struct to not use direct field access, then I redefined the old struct to be a union following Warren's design and refactored the string implementation.

The only behavior change relative to the current NEP draft is that `np.empty(string_array)` *always* returns an array filled with empty strings, no matter what NA object is set for the dtype. This is both for expediency (I'd need to add a new empty initialization hook in the numpy dtype API to keep the old behavior) and because on second thought it makes more sense.

I changed the naming a bit relative to Warren's proof-of-concept to make things make more sense to me but other than that there should only be minimal changes, if any. The changes to support small string optimization should be contained to `static_string.c` if you want to only look at that.

@seberg if you have a chance it would be great to have you look at this too.