### PR TITLE
Arena allocator refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           then
               rm -r build
           fi
-          meson setup build -Db_sanitize=address,undefined
+          meson setup build -Db_sanitize=address,undefined -Dbuildtype=debugoptimized
           python -m build --no-isolation --wheel -Cbuilddir=build --config-setting='compile-args=-v'
           find ./dist/*.whl | xargs python -m pip install
       - name: Run stringdtype tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
           then
               rm -r build
           fi
-          meson setup build -Db_sanitize=address,undefined -Dbuildtype=debugoptimized
-          python -m build --no-isolation --wheel -Cbuilddir=build --config-setting='compile-args=-v'
+          meson setup build -Db_sanitize=address,undefined
+          python -m build --no-isolation --wheel -Cbuilddir=build --config-setting='compile-args=-v' -Csetup-args="-Dbuildtype=debug"
           find ./dist/*.whl | xargs python -m pip install
       - name: Run stringdtype tests
         working-directory: stringdtype

--- a/asciidtype/asciidtype/src/asciidtype_main.c
+++ b/asciidtype/asciidtype/src/asciidtype_main.c
@@ -22,7 +22,7 @@ PyInit__asciidtype_main(void)
         return NULL;
     }
 
-    if (import_experimental_dtype_api(14) < 0) {
+    if (import_experimental_dtype_api(15) < 0) {
         return NULL;
     }
 

--- a/metadatadtype/metadatadtype/src/metadatadtype_main.c
+++ b/metadatadtype/metadatadtype/src/metadatadtype_main.c
@@ -21,7 +21,7 @@ PyInit__metadatadtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(14) < 0) {
+    if (import_experimental_dtype_api(15) < 0) {
         return NULL;
     }
 

--- a/mpfdtype/mpfdtype/src/mpfdtype_main.c
+++ b/mpfdtype/mpfdtype/src/mpfdtype_main.c
@@ -22,7 +22,7 @@ PyInit__mpfdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(14) < 0) {
+    if (import_experimental_dtype_api(15) < 0) {
         return NULL;
     }
 

--- a/quaddtype/quaddtype/src/quaddtype_main.c
+++ b/quaddtype/quaddtype/src/quaddtype_main.c
@@ -23,7 +23,7 @@ PyInit__quaddtype_main(void)
         return NULL;
 
     // Fail to init if the experimental DType API version 5 isn't supported
-    if (import_experimental_dtype_api(14) < 0) {
+    if (import_experimental_dtype_api(15) < 0) {
         PyErr_SetString(PyExc_ImportError,
                         "Error encountered importing the experimental dtype API.");
         return NULL;

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -97,7 +97,7 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
                 }
             }
             else if (free_and_copy(idescr->allocator, odescr->allocator, s, os,
-                              "string to string cast") == -1) {
+                                   "string to string cast") == -1) {
                 return -1;
             }
         }
@@ -240,7 +240,7 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
             return -1;
         }
         npy_static_string out_ss = {0, NULL};
-        int is_null = npy_load_string(allocator, out_pss, &out_ss);
+        int is_null = npy_string_load(allocator, out_pss, &out_ss);
         if (is_null == -1) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in unicode to string cast");
@@ -373,7 +373,7 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
         npy_static_string name;
         unsigned char *this_string = NULL;
         size_t n_bytes;
-        int is_null = npy_load_string(allocator, ps, &s);
+        int is_null = npy_string_load(allocator, ps, &s);
         if (is_null == -1) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in unicode to string cast");
@@ -473,7 +473,7 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        int is_null = npy_load_string(allocator, ps, &s);
+        int is_null = npy_string_load(allocator, ps, &s);
         if (is_null == -1) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in unicode to string cast");
@@ -577,7 +577,7 @@ string_to_pylong(char *in, int hasnull,
 {
     const npy_packed_static_string *ps = (npy_packed_static_string *)in;
     npy_static_string s = {0, NULL};
-    int isnull = npy_load_string(allocator, ps, &s);
+    int isnull = npy_string_load(allocator, ps, &s);
     if (isnull == -1) {
         PyErr_SetString(PyExc_MemoryError,
                         "Failed to load string converting string to int");
@@ -860,7 +860,7 @@ string_to_pyfloat(char *in, int hasnull,
 {
     const npy_packed_static_string *ps = (npy_packed_static_string *)in;
     npy_static_string s = {0, NULL};
-    int isnull = npy_load_string(allocator, ps, &s);
+    int isnull = npy_string_load(allocator, ps, &s);
     if (isnull == -1) {
         PyErr_SetString(
                 PyExc_MemoryError,
@@ -1104,7 +1104,7 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        int is_null = npy_load_string(allocator, ps, &s);
+        int is_null = npy_string_load(allocator, ps, &s);
         if (is_null == -1) {
             // do we hold the gil in this cast? error handling below seems to
             // think we do

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -42,7 +42,7 @@ string_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
                                      npy_intp *view_offset)
 {
     if (given_descrs[1] == NULL) {
-        loop_descrs[1] = stringdtype_get_unique_array_descr(given_descrs[0]);
+        loop_descrs[1] = stringdtype_finalize_descr(given_descrs[0]);
     }
     else {
         Py_INCREF(given_descrs[1]);

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -42,8 +42,7 @@ string_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
                                      npy_intp *view_offset)
 {
     if (given_descrs[1] == NULL) {
-        Py_INCREF(given_descrs[0]);
-        loop_descrs[1] = given_descrs[0];
+        loop_descrs[1] = stringdtype_get_unique_array_descr(given_descrs[0]);
     }
     else {
         Py_INCREF(given_descrs[1]);
@@ -74,7 +73,6 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
 {
     StringDTypeObject *idescr = (StringDTypeObject *)context->descriptors[0];
     StringDTypeObject *odescr = (StringDTypeObject *)context->descriptors[1];
-    npy_string_allocator *allocator = odescr->allocator;
     int in_hasnull = idescr->na_object != NULL;
     int out_hasnull = odescr->na_object != NULL;
     const npy_static_string *in_na_name = &idescr->na_name;
@@ -88,18 +86,18 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
         const npy_packed_static_string *s = (npy_packed_static_string *)in;
         npy_packed_static_string *os = (npy_packed_static_string *)out;
         if (in != out) {
-            npy_string_free(os, allocator);
             if (in_hasnull && !out_hasnull && npy_string_isnull(s)) {
                 // lossy but this is an unsafe cast so this is OK
-                if (npy_string_newsize(
-                            in_na_name->buf, in_na_name->size, os, allocator) < 0) {
+                npy_string_free(os, odescr->allocator);
+                if (npy_string_newsize(in_na_name->buf, in_na_name->size, os,
+                                       odescr->allocator) < 0) {
                     gil_error(PyExc_MemoryError,
                               "Failed to allocate string in string to string "
                               "cast.");
                 }
             }
-            else if (npy_string_dup(s, os, allocator) < 0) {
-                gil_error(PyExc_MemoryError, "npy_string_dup failed");
+            else if (free_and_copy(idescr->allocator, odescr->allocator, s, os,
+                              "string to string cast") == -1) {
                 return -1;
             }
         }
@@ -231,14 +229,22 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
             return -1;
         }
         npy_packed_static_string *out_pss = (npy_packed_static_string *)out;
-        npy_string_free(out_pss, allocator);
+        if (npy_string_free(out_pss, allocator) < 0) {
+            gil_error(PyExc_MemoryError,
+                      "Failed to deallocate string in unicode to string cast");
+            return -1;
+        }
         if (npy_string_newemptysize(out_num_bytes, out_pss, allocator) < 0) {
             gil_error(PyExc_MemoryError,
                       "Failed to allocate string in unicode to string cast");
             return -1;
         }
         npy_static_string out_ss = {0, NULL};
-        npy_load_string(out_pss, &out_ss);
+        int is_null = npy_load_string(allocator, out_pss, &out_ss);
+        if (is_null == -1) {
+            gil_error(PyExc_MemoryError,
+                      "Failed to load string in unicode to string cast");
+        }
         // ignores const to fill in the buffer
         char *out_buf = (char *)out_ss.buf;
         for (size_t i = 0; i < num_codepoints; i++) {
@@ -347,6 +353,7 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
                   NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    npy_string_allocator *allocator = descr->allocator;
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
     const npy_static_string *default_string = &descr->default_string;
@@ -366,8 +373,12 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
         npy_static_string name;
         unsigned char *this_string = NULL;
         size_t n_bytes;
-        int is_null = npy_load_string(ps, &s);
-        if (is_null) {
+        int is_null = npy_load_string(allocator, ps, &s);
+        if (is_null == -1) {
+            gil_error(PyExc_MemoryError,
+                      "Failed to load string in unicode to string cast");
+        }
+        else if (is_null) {
             if (has_null && !has_string_na) {
                 // lossy but not much else we can do
                 name = *na_name;
@@ -447,6 +458,7 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
                NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    npy_string_allocator *allocator = descr->allocator;
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
     const npy_static_string *default_string = &descr->default_string;
@@ -461,7 +473,12 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (npy_load_string(ps, &s)) {
+        int is_null = npy_load_string(allocator, ps, &s);
+        if (is_null == -1) {
+            gil_error(PyExc_MemoryError,
+                      "Failed to load string in unicode to string cast");
+        }
+        else if (is_null) {
             if (has_null && !has_string_na) {
                 // numpy treats NaN as truthy, following python
                 *out = (npy_bool)1;
@@ -510,7 +527,11 @@ bool_to_string(PyArrayMethod_Context *context, char *const data[],
 
     while (N--) {
         npy_packed_static_string *out_pss = (npy_packed_static_string *)out;
-        npy_string_free(out_pss, allocator);
+        if (npy_string_free(out_pss, allocator) < 0) {
+            gil_error(PyExc_MemoryError,
+                      "Failed to deallocate string in bool to string cast");
+            return -1;
+        }
         char *ret_val = NULL;
         size_t size = 0;
         if ((npy_bool)(*in) == 1) {
@@ -551,11 +572,18 @@ static char *b2s_name = "cast_Bool_to_StringDType";
 
 static PyObject *
 string_to_pylong(char *in, int hasnull,
-                 const npy_static_string *default_string)
+                 const npy_static_string *default_string,
+                 npy_string_allocator *allocator)
 {
     const npy_packed_static_string *ps = (npy_packed_static_string *)in;
     npy_static_string s = {0, NULL};
-    if (npy_load_string(ps, &s)) {
+    int isnull = npy_load_string(allocator, ps, &s);
+    if (isnull == -1) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "Failed to load string converting string to int");
+        return NULL;
+    }
+    else if (isnull) {
         if (hasnull) {
             PyErr_SetString(PyExc_ValueError,
                             "Arrays with missing data cannot be converted to "
@@ -576,9 +604,11 @@ string_to_pylong(char *in, int hasnull,
 
 static npy_longlong
 string_to_uint(char *in, npy_ulonglong *value, int hasnull,
-               const npy_static_string *default_string)
+               const npy_static_string *default_string,
+               npy_string_allocator *allocator)
 {
-    PyObject *pylong_value = string_to_pylong(in, hasnull, default_string);
+    PyObject *pylong_value =
+            string_to_pylong(in, hasnull, default_string, allocator);
     if (pylong_value == NULL) {
         return -1;
     }
@@ -593,9 +623,11 @@ string_to_uint(char *in, npy_ulonglong *value, int hasnull,
 
 static npy_longlong
 string_to_int(char *in, npy_longlong *value, int hasnull,
-              const npy_static_string *default_string)
+              const npy_static_string *default_string,
+              npy_string_allocator *allocator)
 {
-    PyObject *pylong_value = string_to_pylong(in, hasnull, default_string);
+    PyObject *pylong_value =
+            string_to_pylong(in, hasnull, default_string, allocator);
     if (pylong_value == NULL) {
         return -1;
     }
@@ -626,7 +658,12 @@ pyobj_to_string(PyObject *obj, char *out, npy_string_allocator *allocator)
         return -1;
     }
     npy_packed_static_string *out_ss = (npy_packed_static_string *)out;
-    npy_string_free(out_ss, allocator);
+    if (npy_string_free(out_ss, allocator) < 0) {
+        gil_error(PyExc_MemoryError,
+                  "Failed to deallocate string when converting from python "
+                  "string");
+        return -1;
+    }
     if (npy_string_newsize(cstr_val, length, out_ss, allocator) < 0) {
         PyErr_SetString(PyExc_MemoryError,
                         "Failed to allocate numpy string when converting from "
@@ -654,110 +691,111 @@ uint_to_string(unsigned long long in, char *out,
     return pyobj_to_string(pylong_val, out, allocator);
 }
 
-#define STRING_INT_CASTS(typename, typekind, shortname, numpy_tag,           \
-                         printf_code, npy_longtype, longtype)                \
-    static NPY_CASTING string_to_##typename##_resolve_descriptors(           \
-            PyObject *NPY_UNUSED(self),                                      \
-            PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),                        \
-            PyArray_Descr *given_descrs[2], PyArray_Descr *loop_descrs[2],   \
-            npy_intp *NPY_UNUSED(view_offset))                               \
-    {                                                                        \
-        if (given_descrs[1] == NULL) {                                       \
-            loop_descrs[1] = PyArray_DescrNewFromType(numpy_tag);            \
-        }                                                                    \
-        else {                                                               \
-            Py_INCREF(given_descrs[1]);                                      \
-            loop_descrs[1] = given_descrs[1];                                \
-        }                                                                    \
-                                                                             \
-        Py_INCREF(given_descrs[0]);                                          \
-        loop_descrs[0] = given_descrs[0];                                    \
-                                                                             \
-        return NPY_UNSAFE_CASTING;                                           \
-    }                                                                        \
-                                                                             \
-    static int string_to_##                                                  \
-            typename(PyArrayMethod_Context * context, char *const data[],    \
-                     npy_intp const dimensions[], npy_intp const strides[],  \
-                     NpyAuxData *NPY_UNUSED(auxdata))                        \
-    {                                                                        \
-        StringDTypeObject *descr =                                           \
-                ((StringDTypeObject *)context->descriptors[0]);              \
-        int hasnull = descr->na_object != NULL;                              \
-        const npy_static_string *default_string = &descr->default_string;    \
-                                                                             \
-        npy_intp N = dimensions[0];                                          \
-        char *in = data[0];                                                  \
-        npy_##typename *out = (npy_##typename *)data[1];                     \
-                                                                             \
-        npy_intp in_stride = strides[0];                                     \
-        npy_intp out_stride = strides[1] / sizeof(npy_##typename);           \
-                                                                             \
-        while (N--) {                                                        \
-            npy_longtype value;                                              \
-            if (string_to_##typekind(in, &value, hasnull, default_string) != \
-                0) {                                                         \
-                return -1;                                                   \
-            }                                                                \
-            *out = (npy_##typename)value;                                    \
-            if (*out != value) {                                             \
-                /* out of bounds, raise error following NEP 50 behavior */   \
-                PyErr_Format(PyExc_OverflowError,                            \
-                             "Integer %" #printf_code                        \
-                             " is out of bounds "                            \
-                             "for " #typename,                               \
-                             value);                                         \
-                return -1;                                                   \
-            }                                                                \
-            in += in_stride;                                                 \
-            out += out_stride;                                               \
-        }                                                                    \
-                                                                             \
-        return 0;                                                            \
-    }                                                                        \
-                                                                             \
-    static PyType_Slot s2##shortname##_slots[] = {                           \
-            {NPY_METH_resolve_descriptors,                                   \
-             &string_to_##typename##_resolve_descriptors},                   \
-            {NPY_METH_strided_loop, &string_to_##typename},                  \
-            {0, NULL}};                                                      \
-                                                                             \
-    static char *s2##shortname##_name = "cast_StringDType_to_" #typename;    \
-                                                                             \
-    static int typename##_to_string(                                         \
-            PyArrayMethod_Context *context, char *const data[],              \
-            npy_intp const dimensions[], npy_intp const strides[],           \
-            NpyAuxData *NPY_UNUSED(auxdata))                                 \
-    {                                                                        \
-        npy_intp N = dimensions[0];                                          \
-        npy_##typename *in = (npy_##typename *)data[0];                      \
-        char *out = data[1];                                                 \
-                                                                             \
-        npy_intp in_stride = strides[0] / sizeof(npy_##typename);            \
-        npy_intp out_stride = strides[1];                                    \
-                                                                             \
-        StringDTypeObject *descr =                                           \
-                (StringDTypeObject *)context->descriptors[1];                \
-        npy_string_allocator *allocator = descr->allocator;                  \
-                                                                             \
-        while (N--) {                                                        \
-            if (typekind##_to_string((longtype)*in, out, allocator) != 0) {  \
-                return -1;                                                   \
-            }                                                                \
-                                                                             \
-            in += in_stride;                                                 \
-            out += out_stride;                                               \
-        }                                                                    \
-                                                                             \
-        return 0;                                                            \
-    }                                                                        \
-                                                                             \
-    static PyType_Slot shortname##2s_slots [] = {                            \
-            {NPY_METH_resolve_descriptors,                                   \
-             &any_to_string_UNSAFE_resolve_descriptors},                     \
-            {NPY_METH_strided_loop, &typename##_to_string},                  \
-            {0, NULL}};                                                      \
-                                                                             \
+#define STRING_INT_CASTS(typename, typekind, shortname, numpy_tag,          \
+                         printf_code, npy_longtype, longtype)               \
+    static NPY_CASTING string_to_##typename##_resolve_descriptors(          \
+            PyObject *NPY_UNUSED(self),                                     \
+            PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),                       \
+            PyArray_Descr *given_descrs[2], PyArray_Descr *loop_descrs[2],  \
+            npy_intp *NPY_UNUSED(view_offset))                              \
+    {                                                                       \
+        if (given_descrs[1] == NULL) {                                      \
+            loop_descrs[1] = PyArray_DescrNewFromType(numpy_tag);           \
+        }                                                                   \
+        else {                                                              \
+            Py_INCREF(given_descrs[1]);                                     \
+            loop_descrs[1] = given_descrs[1];                               \
+        }                                                                   \
+                                                                            \
+        Py_INCREF(given_descrs[0]);                                         \
+        loop_descrs[0] = given_descrs[0];                                   \
+                                                                            \
+        return NPY_UNSAFE_CASTING;                                          \
+    }                                                                       \
+                                                                            \
+    static int string_to_##                                                 \
+            typename(PyArrayMethod_Context * context, char *const data[],   \
+                     npy_intp const dimensions[], npy_intp const strides[], \
+                     NpyAuxData *NPY_UNUSED(auxdata))                       \
+    {                                                                       \
+        StringDTypeObject *descr =                                          \
+                ((StringDTypeObject *)context->descriptors[0]);             \
+        npy_string_allocator *allocator = descr->allocator;                 \
+        int hasnull = descr->na_object != NULL;                             \
+        const npy_static_string *default_string = &descr->default_string;   \
+                                                                            \
+        npy_intp N = dimensions[0];                                         \
+        char *in = data[0];                                                 \
+        npy_##typename *out = (npy_##typename *)data[1];                    \
+                                                                            \
+        npy_intp in_stride = strides[0];                                    \
+        npy_intp out_stride = strides[1] / sizeof(npy_##typename);          \
+                                                                            \
+        while (N--) {                                                       \
+            npy_longtype value;                                             \
+            if (string_to_##typekind(in, &value, hasnull, default_string,   \
+                                     allocator) != 0) {                     \
+                return -1;                                                  \
+            }                                                               \
+            *out = (npy_##typename)value;                                   \
+            if (*out != value) {                                            \
+                /* out of bounds, raise error following NEP 50 behavior */  \
+                PyErr_Format(PyExc_OverflowError,                           \
+                             "Integer %" #printf_code                       \
+                             " is out of bounds "                           \
+                             "for " #typename,                              \
+                             value);                                        \
+                return -1;                                                  \
+            }                                                               \
+            in += in_stride;                                                \
+            out += out_stride;                                              \
+        }                                                                   \
+                                                                            \
+        return 0;                                                           \
+    }                                                                       \
+                                                                            \
+    static PyType_Slot s2##shortname##_slots[] = {                          \
+            {NPY_METH_resolve_descriptors,                                  \
+             &string_to_##typename##_resolve_descriptors},                  \
+            {NPY_METH_strided_loop, &string_to_##typename},                 \
+            {0, NULL}};                                                     \
+                                                                            \
+    static char *s2##shortname##_name = "cast_StringDType_to_" #typename;   \
+                                                                            \
+    static int typename##_to_string(                                        \
+            PyArrayMethod_Context *context, char *const data[],             \
+            npy_intp const dimensions[], npy_intp const strides[],          \
+            NpyAuxData *NPY_UNUSED(auxdata))                                \
+    {                                                                       \
+        npy_intp N = dimensions[0];                                         \
+        npy_##typename *in = (npy_##typename *)data[0];                     \
+        char *out = data[1];                                                \
+                                                                            \
+        npy_intp in_stride = strides[0] / sizeof(npy_##typename);           \
+        npy_intp out_stride = strides[1];                                   \
+                                                                            \
+        StringDTypeObject *descr =                                          \
+                (StringDTypeObject *)context->descriptors[1];               \
+        npy_string_allocator *allocator = descr->allocator;                 \
+                                                                            \
+        while (N--) {                                                       \
+            if (typekind##_to_string((longtype)*in, out, allocator) != 0) { \
+                return -1;                                                  \
+            }                                                               \
+                                                                            \
+            in += in_stride;                                                \
+            out += out_stride;                                              \
+        }                                                                   \
+                                                                            \
+        return 0;                                                           \
+    }                                                                       \
+                                                                            \
+    static PyType_Slot shortname##2s_slots [] = {                           \
+            {NPY_METH_resolve_descriptors,                                  \
+             &any_to_string_UNSAFE_resolve_descriptors},                    \
+            {NPY_METH_strided_loop, &typename##_to_string},                 \
+            {0, NULL}};                                                     \
+                                                                            \
     static char *shortname##2s_name = "cast_" #typename "_to_StringDType";
 
 #define DTYPES_AND_CAST_SPEC(shortname, typename)                            \
@@ -817,11 +855,19 @@ STRING_INT_CASTS(ulonglong, uint, ulonglong, NPY_ULONGLONG, llu, npy_ulonglong,
 
 static PyObject *
 string_to_pyfloat(char *in, int hasnull,
-                  const npy_static_string *default_string)
+                  const npy_static_string *default_string,
+                  npy_string_allocator *allocator)
 {
     const npy_packed_static_string *ps = (npy_packed_static_string *)in;
     npy_static_string s = {0, NULL};
-    if (npy_load_string(ps, &s)) {
+    int isnull = npy_load_string(allocator, ps, &s);
+    if (isnull == -1) {
+        PyErr_SetString(
+                PyExc_MemoryError,
+                "Failed to load string while converting string to float");
+        return NULL;
+    }
+    if (isnull) {
         if (hasnull) {
             PyErr_SetString(PyExc_ValueError,
                             "Arrays with missing data cannot be converted to "
@@ -848,6 +894,7 @@ string_to_pyfloat(char *in, int hasnull,
     {                                                                        \
         StringDTypeObject *descr =                                           \
                 (StringDTypeObject *)context->descriptors[0];                \
+        npy_string_allocator *allocator = descr->allocator;                  \
         int hasnull = (descr->na_object != NULL);                            \
         const npy_static_string *default_string = &descr->default_string;    \
                                                                              \
@@ -859,8 +906,8 @@ string_to_pyfloat(char *in, int hasnull,
         npy_intp out_stride = strides[1] / sizeof(npy_##typename);           \
                                                                              \
         while (N--) {                                                        \
-            PyObject *pyfloat_value =                                        \
-                    string_to_pyfloat(in, hasnull, default_string);          \
+            PyObject *pyfloat_value = string_to_pyfloat(                     \
+                    in, hasnull, default_string, allocator);                 \
             if (pyfloat_value == NULL) {                                     \
                 return -1;                                                   \
             }                                                                \
@@ -959,6 +1006,7 @@ string_to_float64(PyArrayMethod_Context *context, char *const data[],
                   NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    npy_string_allocator *allocator = descr->allocator;
     int hasnull = descr->na_object != NULL;
     const npy_static_string *default_string = &descr->default_string;
     npy_intp N = dimensions[0];
@@ -970,7 +1018,7 @@ string_to_float64(PyArrayMethod_Context *context, char *const data[],
 
     while (N--) {
         PyObject *pyfloat_value =
-                string_to_pyfloat(in, hasnull, default_string);
+                string_to_pyfloat(in, hasnull, default_string, allocator);
         if (pyfloat_value == NULL) {
             return -1;
         }
@@ -1032,6 +1080,7 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
                    NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    npy_string_allocator *allocator = descr->allocator;
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
     const npy_static_string *default_string = &descr->default_string;
@@ -1055,7 +1104,15 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (npy_load_string(ps, &s)) {
+        int is_null = npy_load_string(allocator, ps, &s);
+        if (is_null == -1) {
+            // do we hold the gil in this cast? error handling below seems to
+            // think we do
+            PyErr_SetString(
+                    PyExc_MemoryError,
+                    "Failed to load string in string to datetime cast");
+        }
+        if (is_null) {
             if (has_null && !has_string_na) {
                 *out = NPY_DATETIME_NAT;
                 goto next_step;
@@ -1114,7 +1171,12 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
 
     while (N--) {
         npy_packed_static_string *out_pss = (npy_packed_static_string *)out;
-        npy_string_free(out_pss, allocator);
+        if (npy_string_free(out_pss, allocator) < 0) {
+            gil_error(
+                    PyExc_MemoryError,
+                    "Failed to deallocate string in datetime to string cast");
+            return -1;
+        }
         if (*in == NPY_DATETIME_NAT) {
             *out_pss = *NPY_NULL_STRING;
         }

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -370,7 +370,7 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        npy_static_string name;
+        npy_static_string name = {0, NULL};
         unsigned char *this_string = NULL;
         size_t n_bytes;
         int is_null = npy_string_load(allocator, ps, &s);

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -104,7 +104,7 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
     snew->array_owned = 0;
 
     npy_static_string default_string = {0, NULL};
-    if (npy_load_string(allocator, &snew->packed_default_string,
+    if (npy_string_load(allocator, &snew->packed_default_string,
                         &default_string) == -1) {
         PyErr_SetString(PyExc_MemoryError,
                         "Failed to load packed string while "
@@ -114,7 +114,7 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
     }
 
     npy_static_string na_name = {0, NULL};
-    if (npy_load_string(allocator, &snew->packed_na_name, &na_name) == -1) {
+    if (npy_string_load(allocator, &snew->packed_na_name, &na_name) == -1) {
         PyErr_SetString(PyExc_MemoryError,
                         "Failed to load packed string while "
                         "creating StringDType instance.");
@@ -317,7 +317,7 @@ stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
     npy_packed_static_string *psdata = (npy_packed_static_string *)dataptr;
     npy_static_string sdata = {0, NULL};
     int hasnull = descr->na_object != NULL;
-    int is_null = npy_load_string(descr->allocator, psdata, &sdata);
+    int is_null = npy_string_load(descr->allocator, psdata, &sdata);
 
     if (is_null < 0) {
         PyErr_SetString(PyExc_MemoryError,
@@ -387,10 +387,10 @@ _compare(void *a, void *b, StringDTypeObject *descr_a,
     npy_static_string *default_string = &descr_a->default_string;
     const npy_packed_static_string *ps_a = (npy_packed_static_string *)a;
     npy_static_string s_a = {0, NULL};
-    int a_is_null = npy_load_string(allocator_a, ps_a, &s_a);
+    int a_is_null = npy_string_load(allocator_a, ps_a, &s_a);
     const npy_packed_static_string *ps_b = (npy_packed_static_string *)b;
     npy_static_string s_b = {0, NULL};
-    int b_is_null = npy_load_string(allocator_b, ps_b, &s_b);
+    int b_is_null = npy_string_load(allocator_b, ps_b, &s_b);
     if (NPY_UNLIKELY(a_is_null == -1 || b_is_null == -1)) {
         char *msg = "Failed to load string in string comparison";
         if (hasnull && !(has_string_na && has_nan_na)) {

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -599,7 +599,7 @@ stringdtype_is_known_scalar_type(PyArray_DTypeMeta *NPY_UNUSED(cls),
 }
 
 PyArray_Descr *
-stringdtype_get_unique_array_descr(PyArray_Descr *dtype)
+stringdtype_finalize_descr(PyArray_Descr *dtype)
 {
     StringDTypeObject *sdtype = (StringDTypeObject *)dtype;
     if (sdtype->array_owned == 0) {
@@ -626,7 +626,7 @@ static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_PyArray_ArrFuncs_argmax, &argmax},
         {NPY_DT_PyArray_ArrFuncs_argmin, &argmin},
         {NPY_DT_get_clear_loop, &stringdtype_get_clear_loop},
-        {NPY_DT_get_unique_array_descr, &stringdtype_get_unique_array_descr},
+        {NPY_DT_finalize_descr, &stringdtype_finalize_descr},
         {_NPY_DT_is_known_scalar_type, &stringdtype_is_known_scalar_type},
         {0, NULL}};
 
@@ -851,7 +851,7 @@ init_string_dtype(void)
     PyArrayMethod_Spec **StringDType_casts = get_casts();
 
     PyArrayDTypeMeta_Spec StringDType_DTypeSpec = {
-            .flags = NPY_DT_PARAMETRIC | NPY_DT_UNIQUE_ARRAY_DESCRIPTOR,
+            .flags = NPY_DT_PARAMETRIC,
             .typeobj = StringScalar_Type,
             .slots = StringDType_Slots,
             .casts = StringDType_casts,

--- a/stringdtype/stringdtype/src/dtype.c
+++ b/stringdtype/stringdtype/src/dtype.c
@@ -18,8 +18,14 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
         return NULL;
     }
 
-    npy_string_allocator *allocator =
-            npy_string_new_allocator(PyMem_RawMalloc, PyMem_RawFree);
+    npy_string_allocator *allocator = npy_string_new_allocator(
+            PyMem_RawMalloc, PyMem_RawFree, PyMem_RawRealloc);
+
+    if (allocator == NULL) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "Failed to create string allocator");
+        return NULL;
+    }
 
     Py_XINCREF(na_object);
     ((StringDTypeObject *)new)->na_object = na_object;
@@ -36,7 +42,9 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
             const char *buf = PyUnicode_AsUTF8AndSize(na_object, &size);
             if (npy_string_newsize(buf, (size_t)size, &packed_default_string,
                                    allocator) < 0) {
-                PyErr_NoMemory();
+                PyErr_SetString(PyExc_MemoryError,
+                                "Failed to allocate string while creating "
+                                "StringDType instance.");
                 Py_DECREF(new);
                 return NULL;
             }
@@ -68,9 +76,16 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
 
         Py_ssize_t size = 0;
         const char *utf8_ptr = PyUnicode_AsUTF8AndSize(na_pystr, &size);
+        if (utf8_ptr == NULL) {
+            Py_DECREF(new);
+            Py_DECREF(na_pystr);
+            return NULL;
+        }
         if (npy_string_newsize(utf8_ptr, (size_t)size, &packed_na_name,
-                               allocator)) {
-            PyErr_NoMemory();
+                               allocator) < 0) {
+            PyErr_SetString(PyExc_MemoryError,
+                            "Failed to allocate string while creating "
+                            "StringDType instance.");
             Py_DECREF(new);
             Py_DECREF(na_pystr);
             return NULL;
@@ -86,12 +101,27 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
     snew->packed_na_name = packed_na_name;
     snew->coerce = coerce;
     snew->allocator = allocator;
+    snew->array_owned = 0;
 
     npy_static_string default_string = {0, NULL};
-    npy_load_string(&snew->packed_default_string, &default_string);
+    if (npy_load_string(allocator, &snew->packed_default_string,
+                        &default_string) == -1) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "Failed to load packed string while "
+                        "creating StringDType instance.");
+        Py_DECREF(snew);
+        return NULL;
+    }
 
     npy_static_string na_name = {0, NULL};
-    npy_load_string(&snew->packed_na_name, &na_name);
+    if (npy_load_string(allocator, &snew->packed_na_name, &na_name) == -1) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "Failed to load packed string while "
+                        "creating StringDType instance.");
+
+        Py_DECREF(snew);
+        return NULL;
+    }
 
     snew->na_name = na_name;
     snew->default_string = default_string;
@@ -112,18 +142,57 @@ new_stringdtype_instance(PyObject *na_object, int coerce)
     return new;
 }
 
+// sets the logical rules for determining equality between dtype instances
+int
+_eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona)
+{
+    if (scoerce != ocoerce) {
+        return 0;
+    }
+    else if (sna == ona) {
+        // Pointer equality catches pandas.NA and other NA singletons.
+        // Also much faster when comparing two dtype instances that share
+        // the same na_object.
+        return 1;
+    }
+    else if (PyFloat_Check(sna) && PyFloat_Check(ona)) {
+        // nan check catches np.nan and float('nan')
+        double sna_float = PyFloat_AsDouble(sna);
+        if (sna_float == -1.0 && PyErr_Occurred()) {
+            return -1;
+        }
+        double ona_float = PyFloat_AsDouble(ona);
+        if (ona_float == -1.0 && PyErr_Occurred()) {
+            return -1;
+        }
+        if (npy_isnan(sna_float) && npy_isnan(ona_float)) {
+            return 1;
+        }
+    }
+    // could have two distinct instances that compare equal
+    return PyObject_RichCompareBool(sna, ona, Py_EQ);
+}
+
 /*
  * This is used to determine the correct dtype to return when dealing
  * with a mix of different dtypes (for example when creating an array
- * from a list of scalars). Since StringDType doesn't have any parameters,
- * we can safely always return the first one.
+ * from a list of scalars).
  */
 static StringDTypeObject *
-common_instance(StringDTypeObject *dtype1,
-                StringDTypeObject *NPY_UNUSED(dtype2))
+common_instance(StringDTypeObject *dtype1, StringDTypeObject *dtype2)
 {
-    Py_INCREF(dtype1);
-    return dtype1;
+    int eq = _eq_comparison(dtype1->coerce, dtype2->coerce, dtype1->na_object,
+                            dtype2->na_object);
+
+    if (eq <= 0) {
+        PyErr_SetString(
+                PyExc_ValueError,
+                "Cannot find common instance for unequal dtype instances");
+        return NULL;
+    }
+
+    return (StringDTypeObject *)new_stringdtype_instance(dtype1->na_object,
+                                                         dtype1->coerce);
 }
 
 /*
@@ -173,6 +242,7 @@ get_value(PyObject *scalar, int coerce)
             }
         }
     }
+
     // attempt to decode as UTF8
     return PyUnicode_AsUTF8String(scalar);
 }
@@ -187,9 +257,7 @@ string_discover_descriptor_from_pyobject(PyTypeObject *NPY_UNUSED(cls),
     }
 
     PyArray_Descr *ret = (PyArray_Descr *)new_stringdtype_instance(NULL, 1);
-    if (ret == NULL) {
-        return NULL;
-    }
+
     return ret;
 }
 
@@ -202,7 +270,11 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
 
     // free if dataptr holds preexisting string data,
     // npy_string_free does a NULL check and checks for small strings
-    npy_string_free(sdata, descr->allocator);
+    if (npy_string_free(sdata, descr->allocator) < 0) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "String deallocation failed in StringDType setitem");
+        return -1;
+    }
 
     // borrow reference
     PyObject *na_object = descr->na_object;
@@ -227,7 +299,9 @@ stringdtype_setitem(StringDTypeObject *descr, PyObject *obj, char **dataptr)
         }
 
         if (npy_string_newsize(val, length, sdata, descr->allocator) < 0) {
-            PyErr_NoMemory();
+            PyErr_SetString(PyExc_MemoryError,
+                            "Failed to allocate string during StringDType "
+                            "setitem");
             Py_DECREF(val_obj);
             return -1;
         }
@@ -243,8 +317,14 @@ stringdtype_getitem(StringDTypeObject *descr, char **dataptr)
     npy_packed_static_string *psdata = (npy_packed_static_string *)dataptr;
     npy_static_string sdata = {0, NULL};
     int hasnull = descr->na_object != NULL;
+    int is_null = npy_load_string(descr->allocator, psdata, &sdata);
 
-    if (npy_load_string(psdata, &sdata)) {
+    if (is_null < 0) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "Failed to load string in StringDType getitem");
+        return NULL;
+    }
+    else if (is_null == 1) {
         if (hasnull) {
             PyObject *na_object = descr->na_object;
             Py_INCREF(na_object);
@@ -289,29 +369,45 @@ int
 compare(void *a, void *b, void *arr)
 {
     StringDTypeObject *descr = (StringDTypeObject *)PyArray_DESCR(arr);
-    return _compare(a, b, descr);
+    return _compare(a, b, descr, descr);
 }
 
 int
-_compare(void *a, void *b, StringDTypeObject *descr)
+_compare(void *a, void *b, StringDTypeObject *descr_a,
+         StringDTypeObject *descr_b)
 {
-    int hasnull = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    int has_nan_na = descr->has_nan_na;
-    if (hasnull && !(has_string_na && has_nan_na)) {
-        // check if an error occured already to avoid setting an error again
-        if (PyErr_Occurred()) {
-            return 0;
-        }
-    }
-    npy_static_string *default_string = &descr->default_string;
+    npy_string_allocator *allocator_a = descr_a->allocator;
+    npy_string_allocator *allocator_b = descr_b->allocator;
+    // descr_a and descr_b are either the same object or objects
+    // the are equal, so we can refer only to descr_a safely
+    // this is enforced in the resolve_descriptors for comparisons
+    int hasnull = descr_a->na_object != NULL;
+    int has_string_na = descr_a->has_string_na;
+    int has_nan_na = descr_a->has_nan_na;
+    npy_static_string *default_string = &descr_a->default_string;
     const npy_packed_static_string *ps_a = (npy_packed_static_string *)a;
     npy_static_string s_a = {0, NULL};
-    int a_is_null = npy_load_string(ps_a, &s_a);
+    int a_is_null = npy_load_string(allocator_a, ps_a, &s_a);
     const npy_packed_static_string *ps_b = (npy_packed_static_string *)b;
     npy_static_string s_b = {0, NULL};
-    int b_is_null = npy_load_string(ps_b, &s_b);
-    if (NPY_UNLIKELY(a_is_null || b_is_null)) {
+    int b_is_null = npy_load_string(allocator_b, ps_b, &s_b);
+    if (NPY_UNLIKELY(a_is_null == -1 || b_is_null == -1)) {
+        char *msg = "Failed to load string in string comparison";
+        if (hasnull && !(has_string_na && has_nan_na)) {
+            // we hold the gil in this branch
+            if (PyErr_Occurred()) {
+                return 0;
+            }
+            PyErr_SetString(PyExc_MemoryError, msg);
+        }
+        else {
+            // has a check for PyErr_Occurred so error
+            // only gets set once
+            gil_error(PyExc_MemoryError, msg);
+        }
+        return 0;
+    }
+    else if (NPY_UNLIKELY(a_is_null || b_is_null)) {
         if (hasnull && !has_string_na) {
             if (has_nan_na) {
                 if (a_is_null) {
@@ -387,7 +483,11 @@ stringdtype_clear_loop(void *NPY_UNUSED(traverse_context),
     while (size--) {
         npy_packed_static_string *sdata = (npy_packed_static_string *)data;
         if (data != NULL) {
-            npy_string_free(sdata, sdescr->allocator);
+            if (npy_string_free(sdata, sdescr->allocator) < 0) {
+                gil_error(PyExc_MemoryError,
+                          "String deallocation failed in clear loop");
+                return -1;
+            }
             memset(data, 0, sizeof(npy_packed_static_string));
         }
         data += stride;
@@ -407,33 +507,6 @@ stringdtype_get_clear_loop(void *NPY_UNUSED(traverse_context),
 {
     *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
     *out_loop = &stringdtype_clear_loop;
-    return 0;
-}
-
-static int
-stringdtype_fill_zero_loop(void *NPY_UNUSED(traverse_context),
-                           PyArray_Descr *NPY_UNUSED(descr), char *data,
-                           npy_intp size, npy_intp stride,
-                           NpyAuxData *NPY_UNUSED(auxdata))
-{
-    while (size--) {
-        *(npy_packed_static_string *)(data) = *NPY_EMPTY_STRING;
-        data += stride;
-    }
-    return 0;
-}
-
-static int
-stringdtype_get_fill_zero_loop(void *NPY_UNUSED(traverse_context),
-                               PyArray_Descr *NPY_UNUSED(descr),
-                               int NPY_UNUSED(aligned),
-                               npy_intp NPY_UNUSED(fixed_stride),
-                               traverse_loop_function **out_loop,
-                               NpyAuxData **NPY_UNUSED(out_auxdata),
-                               NPY_ARRAYMETHOD_FLAGS *flags)
-{
-    *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
-    *out_loop = &stringdtype_fill_zero_loop;
     return 0;
 }
 
@@ -525,6 +598,21 @@ stringdtype_is_known_scalar_type(PyArray_DTypeMeta *NPY_UNUSED(cls),
     return 0;
 }
 
+PyArray_Descr *
+stringdtype_get_unique_array_descr(PyArray_Descr *dtype)
+{
+    StringDTypeObject *sdtype = (StringDTypeObject *)dtype;
+    if (sdtype->array_owned == 0) {
+        sdtype->array_owned = 1;
+        Py_INCREF(dtype);
+        return dtype;
+    }
+    StringDTypeObject *ret = (StringDTypeObject *)new_stringdtype_instance(
+            sdtype->na_object, sdtype->coerce);
+    ret->array_owned = 1;
+    return (PyArray_Descr *)ret;
+}
+
 static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_common_instance, &common_instance},
         {NPY_DT_common_dtype, &common_dtype},
@@ -538,7 +626,7 @@ static PyType_Slot StringDType_Slots[] = {
         {NPY_DT_PyArray_ArrFuncs_argmax, &argmax},
         {NPY_DT_PyArray_ArrFuncs_argmin, &argmin},
         {NPY_DT_get_clear_loop, &stringdtype_get_clear_loop},
-        {NPY_DT_get_fill_zero_loop, &stringdtype_get_fill_zero_loop},
+        {NPY_DT_get_unique_array_descr, &stringdtype_get_unique_array_descr},
         {_NPY_DT_is_known_scalar_type, &stringdtype_is_known_scalar_type},
         {0, NULL}};
 
@@ -557,9 +645,7 @@ stringdtype_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    PyObject *ret = new_stringdtype_instance(na_object, coerce);
-
-    return ret;
+    return new_stringdtype_instance(na_object, coerce);
 }
 
 static void
@@ -700,37 +786,11 @@ StringDType_richcompare(PyObject *self, PyObject *other, int op)
     StringDTypeObject *sself = (StringDTypeObject *)self;
     StringDTypeObject *sother = (StringDTypeObject *)other;
 
-    int eq = 0;
-    PyObject *sna = sself->na_object;
-    PyObject *ona = sother->na_object;
+    int eq = _eq_comparison(sself->coerce, sother->coerce, sself->na_object,
+                            sother->na_object);
 
-    if (sself->coerce != sother->coerce) {
-        eq = 0;
-    }
-    else if (sna == ona) {
-        // pointer equality catches pandas.NA and other NA singletons
-        eq = 1;
-    }
-    else if (PyFloat_Check(sna) && PyFloat_Check(ona)) {
-        // nan check catches np.nan and float('nan')
-        double sna_float = PyFloat_AsDouble(sna);
-        if (sna_float == -1.0 && PyErr_Occurred()) {
-            return NULL;
-        }
-        double ona_float = PyFloat_AsDouble(ona);
-        if (ona_float == -1.0 && PyErr_Occurred()) {
-            return NULL;
-        }
-        if (npy_isnan(sna_float) && npy_isnan(ona_float)) {
-            eq = 1;
-        }
-    }
-    else {
-        // finally check if a python equals comparison returns True
-        eq = PyObject_RichCompareBool(sna, ona, Py_EQ);
-        if (eq == -1) {
-            return NULL;
-        }
+    if (eq == -1) {
+        return NULL;
     }
 
     PyObject *ret = Py_NotImplemented;
@@ -791,7 +851,7 @@ init_string_dtype(void)
     PyArrayMethod_Spec **StringDType_casts = get_casts();
 
     PyArrayDTypeMeta_Spec StringDType_DTypeSpec = {
-            .flags = NPY_DT_PARAMETRIC,
+            .flags = NPY_DT_PARAMETRIC | NPY_DT_UNIQUE_ARRAY_DESCRIPTOR,
             .typeobj = StringScalar_Type,
             .slots = StringDType_Slots,
             .casts = StringDType_casts,
@@ -833,6 +893,31 @@ gil_error(PyObject *type, const char *msg)
 {
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
-    PyErr_SetString(type, msg);
+    if (!PyErr_Occurred()) {
+        PyErr_SetString(type, msg);
+    }
     PyGILState_Release(gstate);
+}
+
+int
+free_and_copy(npy_string_allocator *in_allocator,
+              npy_string_allocator *out_allocator,
+              const npy_packed_static_string *in,
+              npy_packed_static_string *out, const char *location)
+{
+    if (npy_string_free(out, out_allocator) < 0) {
+        char message[200];
+        snprintf(message, sizeof(message), "Failed to deallocate string in %s",
+                 location);
+        gil_error(PyExc_MemoryError, message);
+        return -1;
+    }
+    if (npy_string_dup(in, out, in_allocator, out_allocator) < 0) {
+        char message[200];
+        snprintf(message, sizeof(message), "Failed to allocate string in %s",
+                 location);
+        gil_error(PyExc_MemoryError, message);
+        return -1;
+    }
+    return 0;
 }

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -70,7 +70,7 @@ free_and_copy(npy_string_allocator *in_allocator,
               npy_packed_static_string *out, const char *location);
 
 PyArray_Descr *
-stringdtype_get_unique_array_descr(PyArray_Descr *dtype);
+stringdtype_finalize_descr(PyArray_Descr *dtype);
 
 int
 _eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona);

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -29,6 +29,7 @@ typedef struct {
     npy_packed_static_string packed_default_string;
     npy_static_string na_name;
     npy_packed_static_string packed_na_name;
+    npy_string_allocator *allocator;
 } StringDTypeObject;
 
 typedef struct {

--- a/stringdtype/stringdtype/src/dtype.h
+++ b/stringdtype/stringdtype/src/dtype.h
@@ -25,6 +25,7 @@ typedef struct {
     int coerce;
     int has_nan_na;
     int has_string_na;
+    int array_owned;
     npy_static_string default_string;
     npy_packed_static_string packed_default_string;
     npy_static_string na_name;
@@ -46,7 +47,8 @@ int
 init_string_dtype(void);
 
 int
-_compare(void *, void *, StringDTypeObject *);
+_compare(void *a, void *b, StringDTypeObject *descr_a,
+         StringDTypeObject *descr_b);
 
 int
 init_string_na_object(PyObject *mod);
@@ -60,5 +62,17 @@ gil_error(PyObject *type, const char *msg);
 
 // from dtypemeta.h, not public in numpy
 #define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))
+
+int
+free_and_copy(npy_string_allocator *in_allocator,
+              npy_string_allocator *out_allocator,
+              const npy_packed_static_string *in,
+              npy_packed_static_string *out, const char *location);
+
+PyArray_Descr *
+stringdtype_get_unique_array_descr(PyArray_Descr *dtype);
+
+int
+_eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona);
 
 #endif /*_NPY_DTYPE_H*/

--- a/stringdtype/stringdtype/src/main.c
+++ b/stringdtype/stringdtype/src/main.c
@@ -94,7 +94,7 @@ PyInit__main(void)
 {
     import_array();
 
-    if (import_experimental_dtype_api(14) < 0) {
+    if (import_experimental_dtype_api(15) < 0) {
         return NULL;
     }
 

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -1,14 +1,15 @@
 #include "static_string.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #if NPY_BYTE_ORDER == NPY_LITTLE_ENDIAN
 
-// the high byte in vstring.size is resolved for flags
+// the high byte in vstring.size is reserved for flags
 // SSSS SSSF
 
 typedef struct _npy_static_string_t {
-    char *buf;
+    size_t offset;
     size_t size;
 } _npy_static_string_t;
 
@@ -19,12 +20,12 @@ typedef struct _short_string_buffer {
 
 #elif NPY_BYTE_ORDER == NPY_BIG_ENDIAN
 
-// the high byte in vstring.size is resolved for flags
+// the high byte in vstring.size is reserved for flags
 // FSSS SSSS
 
 typedef struct _npy_static_string_t {
     size_t size;
-    char *buf;
+    size_t offset;
 } _npy_static_string_t;
 
 typedef struct _short_string_buffer {
@@ -39,9 +40,10 @@ typedef union _npy_static_string_u {
     _short_string_buffer direct_buffer;
 } _npy_static_string_u;
 
-// room for two more flags with values 0x20 and 0x10
-#define NPY_STRING_MISSING 0x80  // 1000 0000
-#define NPY_STRING_SHORT 0x40    // 0100 0000
+#define NPY_STRING_MISSING 0x80      // 1000 0000
+#define NPY_STRING_SHORT 0x40        // 0100 0000
+#define NPY_STRING_ARENA_FREED 0x20  // 0010 0000
+#define NPY_STRING_ON_HEAP 0x10      // 0001 0000
 
 // short string sizes fit in a 4-bit integer
 #define NPY_SHORT_STRING_SIZE_MASK 0x0F  // 0000 1111
@@ -63,17 +65,123 @@ const _npy_static_string_u null_string_u = {
 const npy_packed_static_string *NPY_NULL_STRING =
         (npy_packed_static_string *)&null_string_u;
 
+#define VSTRING_FLAGS(string) \
+    string->direct_buffer.flags_and_size & ~NPY_SHORT_STRING_SIZE_MASK;
+#define HIGH_BYTE_MASK ((size_t)0XFF << 8 * (sizeof(size_t) - 1))
+#define VSTRING_SIZE(string) (string->vstring.size & ~HIGH_BYTE_MASK)
+
+typedef struct npy_string_arena {
+    size_t cursor;
+    size_t size;
+    char *buffer;
+} npy_string_arena;
+
 struct npy_string_allocator {
     npy_string_malloc_func malloc;
     npy_string_free_func free;
+    npy_string_realloc_func realloc;
+    npy_string_arena arena;
 };
 
+void
+set_vstring_size(_npy_static_string_u *str, size_t size)
+{
+    unsigned char *flags = &str->direct_buffer.flags_and_size;
+    unsigned char current_flags = *flags & ~NPY_SHORT_STRING_SIZE_MASK;
+    str->vstring.size = size;
+    str->direct_buffer.flags_and_size = current_flags;
+}
+
+char *
+vstring_buffer(npy_string_arena *arena, _npy_static_string_u *string)
+{
+    char flags = VSTRING_FLAGS(string);
+    if (flags & NPY_STRING_ON_HEAP) {
+        return (char *)string->vstring.offset;
+    }
+    if (arena->buffer == NULL) {
+        return NULL;
+    }
+    return (char *)((size_t)arena->buffer + string->vstring.offset);
+}
+
+char *
+npy_string_arena_malloc(npy_string_arena *arena, npy_string_realloc_func r,
+                        size_t size)
+{
+    // one extra size_t to store the size of the allocation
+    size_t string_storage_size = size + sizeof(size_t);
+    // expand size to nearest multiple of 8 bytes to ensure 64 bit alignment
+    string_storage_size += (8 - string_storage_size % 8);
+    if ((arena->size - arena->cursor) <= string_storage_size) {
+        // realloc the buffer so there is enough room
+        // first guess is to double the size of the buffer
+        size_t newsize;
+        if (arena->size == 0) {
+            newsize = string_storage_size;
+        }
+        else if (((2 * arena->size) - arena->cursor) > string_storage_size) {
+            newsize = 2 * arena->size;
+        }
+        else {
+            newsize = arena->size + string_storage_size;
+        }
+        if ((arena->cursor + size) >= newsize) {
+            // doubling the current size isn't enough
+            newsize = 2 * (arena->cursor + size);
+        }
+        // realloc passed a NULL pointer acts like malloc
+        char *newbuf = r(arena->buffer, newsize);
+        if (newbuf == NULL) {
+            return NULL;
+        }
+        memset(newbuf + arena->cursor, 0, newsize - arena->cursor);
+        arena->buffer = newbuf;
+        arena->size = newsize;
+    }
+    size_t *size_loc = (size_t *)&arena->buffer[arena->cursor];
+    *size_loc = size;
+    char *ret = &arena->buffer[arena->cursor + sizeof(size_t)];
+    arena->cursor += string_storage_size;
+    return ret;
+}
+
+int
+npy_string_arena_free(npy_string_arena *arena, _npy_static_string_u *str)
+{
+    char *ptr = vstring_buffer(arena, str);
+    if (ptr == NULL) {
+        return -1;
+    }
+    size_t size = VSTRING_SIZE(str);
+    uintptr_t buf_start = (uintptr_t)arena->buffer;
+    uintptr_t ptr_loc = (uintptr_t)ptr;
+    uintptr_t end_loc = ptr_loc + size;
+    uintptr_t buf_end = buf_start + arena->size;
+    if (ptr_loc < buf_start || ptr_loc > buf_end || end_loc > buf_end) {
+        return -1;
+    }
+
+    memset(ptr, 0, size);
+
+    return 0;
+}
+
+static npy_string_arena NEW_ARENA = {0, 0, NULL};
+
 npy_string_allocator *
-npy_string_new_allocator(npy_string_malloc_func m, npy_string_free_func f)
+npy_string_new_allocator(npy_string_malloc_func m, npy_string_free_func f,
+                         npy_string_realloc_func r)
 {
     npy_string_allocator *allocator = m(sizeof(npy_string_allocator));
+    if (allocator == NULL) {
+        return NULL;
+    }
     allocator->malloc = m;
     allocator->free = f;
+    allocator->realloc = r;
+    // arenas don't get created until the dtype is used for array creation
+    allocator->arena = NEW_ARENA;
     return allocator;
 }
 
@@ -81,6 +189,11 @@ void
 npy_string_free_allocator(npy_string_allocator *allocator)
 {
     npy_string_free_func f = allocator->free;
+
+    if (allocator->arena.buffer != NULL) {
+        f(allocator->arena.buffer);
+    }
+
     f(allocator);
 }
 
@@ -107,7 +220,8 @@ is_not_a_vstring(const npy_packed_static_string *s)
 }
 
 int
-npy_load_string(const npy_packed_static_string *packed_string,
+npy_load_string(npy_string_allocator *allocator,
+                const npy_packed_static_string *packed_string,
                 npy_static_string *unpacked_string)
 {
     if (npy_string_isnull(packed_string)) {
@@ -125,10 +239,104 @@ npy_load_string(const npy_packed_static_string *packed_string,
     }
 
     else {
-        unpacked_string->size = string_u->vstring.size;
-        unpacked_string->buf = string_u->vstring.buf;
+        size_t size = VSTRING_SIZE(string_u);
+        char *buf = NULL;
+        if (size > 0) {
+            npy_string_arena *arena = &allocator->arena;
+            if (arena == NULL) {
+                return -1;
+            }
+            buf = vstring_buffer(arena, string_u);
+            if (buf == NULL) {
+                return -1;
+            }
+        }
+        unpacked_string->size = size;
+        unpacked_string->buf = buf;
     }
 
+    return 0;
+}
+
+char *
+heap_or_arena_allocate(npy_string_allocator *allocator,
+                       _npy_static_string_u *to_init_u, size_t size,
+                       int *on_heap)
+{
+    // check if it's a previously heap-allocated string or a short string
+    // that has no heap allocation
+    unsigned char *flags = &to_init_u->direct_buffer.flags_and_size;
+    if (*flags & NPY_STRING_ARENA_FREED) {
+        // Check if there's room for the new string in the existing
+        // allocation. The size is stored one size_t "behind" the beginning of
+        // the allocation.
+        npy_string_arena *arena = &allocator->arena;
+        if (arena == NULL) {
+            return NULL;
+        }
+        char *buf = vstring_buffer(arena, to_init_u);
+        if (buf == NULL) {
+            return NULL;
+        }
+        size_t alloc_size = *((size_t *)(buf - 1));
+        if (size <= alloc_size) {
+            // we have room!
+            *flags = NPY_STRING_ARENA_FREED;
+            return buf;
+        }
+        else {
+            // no room, resort to a heap allocation this leaves the
+            // NPY_STRING_ARENA_FREED flag set to possibly re-use the arena
+            // allocation in the future if there is room for it
+            *flags |= NPY_STRING_ON_HEAP;
+            *on_heap = 1;
+            return allocator->malloc(sizeof(char) * size);
+        }
+    }
+    else if (*flags & NPY_STRING_SHORT) {
+        // have to heap allocate this leaves the NPY_STRING_SHORT flag set to
+        // indicate that there is no room in the arena buffer for strings in
+        // this entry, avoiding possible reallocation of the entire arena
+        // buffer when writing to a single string
+        *flags &= NPY_STRING_ON_HEAP;
+        return allocator->malloc(sizeof(char) * size);
+    }
+    // string isn't previously allocated, so add to existing arena allocation
+    npy_string_arena *arena = &allocator->arena;
+    if (arena == NULL) {
+        return NULL;
+    }
+    return npy_string_arena_malloc(arena, allocator->realloc,
+                                   sizeof(char) * size);
+}
+
+int
+heap_or_arena_deallocate(npy_string_allocator *allocator,
+                         _npy_static_string_u *str_u)
+{
+    unsigned char *flags = &str_u->direct_buffer.flags_and_size;
+    if (*flags & NPY_STRING_ON_HEAP) {
+        // It's a heap string (not in the arena buffer) so it needs to be
+        // deallocated with free(). For heap strings the offset is a raw
+        // address so this cast is safe.
+        allocator->free((char *)str_u->vstring.offset);
+        if (*flags & NPY_STRING_SHORT) {
+            *flags = 0 | NPY_STRING_SHORT;
+        }
+        else {
+            *flags &= ~NPY_STRING_ON_HEAP;
+        }
+    }
+    else if (VSTRING_SIZE(str_u) != 0) {
+        npy_string_arena *arena = &allocator->arena;
+        if (arena == NULL) {
+            return -1;
+        }
+        if (npy_string_arena_free(arena, str_u) < 0) {
+            return -1;
+        }
+        str_u->direct_buffer.flags_and_size |= NPY_STRING_ARENA_FREED;
+    }
     return 0;
 }
 
@@ -137,36 +345,52 @@ npy_string_newsize(const char *init, size_t size,
                    npy_packed_static_string *to_init,
                    npy_string_allocator *allocator)
 {
-    if (size == 0) {
-        *to_init = *NPY_EMPTY_STRING;
-        return 0;
-    }
-
     if (size > NPY_MAX_STRING_SIZE) {
         return -1;
     }
 
     _npy_static_string_u *to_init_u = ((_npy_static_string_u *)to_init);
 
+    unsigned char flags = VSTRING_FLAGS(to_init_u);
+
+    if (size == 0) {
+        *to_init = *NPY_EMPTY_STRING;
+        to_init_u->direct_buffer.flags_and_size |= flags;
+        return 0;
+    }
+
     if (size > NPY_SHORT_STRING_MAX_SIZE) {
-        char *ret_buf = (char *)allocator->malloc(sizeof(char) * size);
+        int on_heap = 0;
+        char *ret_buf =
+                heap_or_arena_allocate(allocator, to_init_u, size, &on_heap);
 
         if (ret_buf == NULL) {
             return -1;
         }
 
-        to_init_u->vstring.size = size;
+        set_vstring_size(to_init_u, size);
 
         memcpy(ret_buf, init, size);
 
-        to_init_u->vstring.buf = ret_buf;
+        if (on_heap) {
+            to_init_u->vstring.offset = (size_t)ret_buf;
+        }
+        else {
+            npy_string_arena *arena = &allocator->arena;
+            if (arena == NULL) {
+                return -1;
+            }
+            to_init_u->vstring.offset =
+                    (size_t)ret_buf - (size_t)arena->buffer;
+        }
     }
     else {
-        // size can be no longer than 7 or 15, depending on CPU architecture
-        // in either case, the size data is in at most the least significant 4
+        // Size can be no larger than 7 or 15, depending on CPU architecture.
+        // In either case, the size data is in at most the least significant 4
         // bits of the byte so it's safe to | with one of 0x10, 0x20, 0x40, or
         // 0x80.
-        to_init_u->direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
+        to_init_u->direct_buffer.flags_and_size =
+                NPY_STRING_SHORT | flags | size;
         memcpy(&(to_init_u->direct_buffer.buf), init, size);
     }
 
@@ -177,54 +401,76 @@ int
 npy_string_newemptysize(size_t size, npy_packed_static_string *out,
                         npy_string_allocator *allocator)
 {
-    if (size == 0) {
-        *out = *NPY_EMPTY_STRING;
-        return 0;
-    }
-
     if (size > NPY_MAX_STRING_SIZE) {
         return -1;
     }
 
     _npy_static_string_u *out_u = (_npy_static_string_u *)out;
 
+    unsigned char flags =
+            out_u->direct_buffer.flags_and_size & ~NPY_SHORT_STRING_SIZE_MASK;
+
+    if (size == 0) {
+        *out = *NPY_EMPTY_STRING;
+        out_u->direct_buffer.flags_and_size |= flags;
+        return 0;
+    }
+
     if (size > NPY_SHORT_STRING_MAX_SIZE) {
-        char *buf = (char *)allocator->malloc(sizeof(char) * size);
+        int on_heap = 0;
+        char *buf = heap_or_arena_allocate(allocator, out_u, size, &on_heap);
 
         if (buf == NULL) {
             return -1;
         }
 
-        out_u->vstring.buf = buf;
-        out_u->vstring.size = size;
+        if (on_heap) {
+            out_u->vstring.offset = (size_t)buf;
+        }
+        else {
+            npy_string_arena *arena = &allocator->arena;
+            if (arena == NULL) {
+                return -1;
+            }
+            out_u->vstring.offset = (size_t)buf - (size_t)arena->buffer;
+        }
+        set_vstring_size(out_u, size);
     }
     else {
-        out_u->direct_buffer.flags_and_size = NPY_STRING_SHORT | size;
+        out_u->direct_buffer.flags_and_size = NPY_STRING_SHORT | flags | size;
     }
 
     return 0;
 }
 
-void
+int
 npy_string_free(npy_packed_static_string *str, npy_string_allocator *allocator)
 {
+    _npy_static_string_u *str_u = (_npy_static_string_u *)str;
     if (is_not_a_vstring(str)) {
-        // zero out
+        // zero out, keeping flags
+        unsigned char *flags = &str_u->direct_buffer.flags_and_size;
+        unsigned char current_flags = *flags & ~NPY_SHORT_STRING_SIZE_MASK;
         memcpy(str, NPY_EMPTY_STRING, sizeof(npy_packed_static_string));
+        *flags |= current_flags;
     }
     else {
-        _npy_static_string_u *str_u = (_npy_static_string_u *)str;
-        if (str_u->vstring.size != 0) {
-            allocator->free(str_u->vstring.buf);
+        if (VSTRING_SIZE(str_u) == 0) {
+            // empty string is a vstring but nothing to deallocate
+            return 0;
         }
-        str_u->vstring.buf = NULL;
-        str_u->vstring.size = 0;
+        if (heap_or_arena_deallocate(allocator, str_u) < 0) {
+            return -1;
+        }
     }
+    return 0;
 }
 
 int
 npy_string_dup(const npy_packed_static_string *in,
-               npy_packed_static_string *out, npy_string_allocator *allocator)
+               npy_packed_static_string *out,
+               npy_string_allocator *in_allocator,
+               npy_string_allocator *out_allocator)
 {
     if (npy_string_isnull(in)) {
         *out = *NPY_NULL_STRING;
@@ -236,9 +482,12 @@ npy_string_dup(const npy_packed_static_string *in,
     }
 
     _npy_static_string_u *in_u = (_npy_static_string_u *)in;
-
-    return npy_string_newsize(in_u->vstring.buf, in_u->vstring.size, out,
-                              allocator);
+    npy_string_arena *arena = &in_allocator->arena;
+    if (arena == NULL) {
+        return -1;
+    }
+    return npy_string_newsize(vstring_buffer(arena, in_u), VSTRING_SIZE(in_u),
+                              out, out_allocator);
 }
 
 int
@@ -246,7 +495,11 @@ npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2)
 {
     size_t minsize = s1->size < s2->size ? s1->size : s2->size;
 
-    int cmp = strncmp(s1->buf, s2->buf, minsize);
+    int cmp = 0;
+
+    if (minsize != 0) {
+        cmp = strncmp(s1->buf, s2->buf, minsize);
+    }
 
     if (cmp == 0) {
         if (s1->size > minsize) {
@@ -274,5 +527,5 @@ npy_string_size(const npy_packed_static_string *packed_string)
                NPY_SHORT_STRING_SIZE_MASK;
     }
 
-    return string_u->vstring.size;
+    return VSTRING_SIZE(string_u);
 }

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -109,7 +109,7 @@ char *
 npy_string_arena_malloc(npy_string_arena *arena, npy_string_realloc_func r,
                         size_t size)
 {
-    if ((arena->size - arena->cursor) <= size) {
+    if ((arena->size - arena->cursor) < size) {
         // realloc the buffer so there is enough room
         // first guess is to double the size of the buffer
         size_t newsize;

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -214,7 +214,7 @@ is_not_a_vstring(const npy_packed_static_string *s)
 }
 
 int
-npy_load_string(npy_string_allocator *allocator,
+npy_string_load(npy_string_allocator *allocator,
                 const npy_packed_static_string *packed_string,
                 npy_static_string *unpacked_string)
 {

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -109,22 +109,18 @@ char *
 npy_string_arena_malloc(npy_string_arena *arena, npy_string_realloc_func r,
                         size_t size)
 {
-    // one extra size_t to store the size of the allocation
-    size_t string_storage_size = size + sizeof(size_t);
-    // expand size to nearest multiple of 8 bytes to ensure 64 bit alignment
-    string_storage_size += (8 - string_storage_size % 8);
-    if ((arena->size - arena->cursor) <= string_storage_size) {
+    if ((arena->size - arena->cursor) <= size) {
         // realloc the buffer so there is enough room
         // first guess is to double the size of the buffer
         size_t newsize;
         if (arena->size == 0) {
-            newsize = string_storage_size;
+            newsize = size;
         }
-        else if (((2 * arena->size) - arena->cursor) > string_storage_size) {
+        else if (((2 * arena->size) - arena->cursor) > size) {
             newsize = 2 * arena->size;
         }
         else {
-            newsize = arena->size + string_storage_size;
+            newsize = arena->size + size;
         }
         if ((arena->cursor + size) >= newsize) {
             // doubling the current size isn't enough
@@ -139,10 +135,8 @@ npy_string_arena_malloc(npy_string_arena *arena, npy_string_realloc_func r,
         arena->buffer = newbuf;
         arena->size = newsize;
     }
-    size_t *size_loc = (size_t *)&arena->buffer[arena->cursor];
-    *size_loc = size;
-    char *ret = &arena->buffer[arena->cursor + sizeof(size_t)];
-    arena->cursor += string_storage_size;
+    char *ret = &arena->buffer[arena->cursor];
+    arena->cursor += size;
     return ret;
 }
 

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -26,10 +26,13 @@ extern const npy_packed_static_string *NPY_NULL_STRING;
 // Handles heap allocations for static strings.
 typedef struct npy_string_allocator npy_string_allocator;
 
+// Typedefs for allocator functions
 typedef void *(*npy_string_malloc_func)(size_t size);
 typedef void (*npy_string_free_func)(void *ptr);
 
-// Use these functions to create a new allocator and destroy allocators
+// Use these functions to create and destroy string allocators, normally
+// users won't use this directly and will use an allocator already
+// attached to a dtype instance
 npy_string_allocator *
 npy_string_new_allocator(npy_string_malloc_func m, npy_string_free_func f);
 void
@@ -51,16 +54,16 @@ npy_string_newsize(const char *init, size_t size,
                    npy_packed_static_string *to_init,
                    npy_string_allocator *allocator);
 
-// Sets len to 0 and if the internal buffer is not already NULL, frees it if
-// it is allocated on the heap and sets it to NULL. Cannot fail.
+// Zeroes out the packed string and frees any heap allocated data. Cannot
+// fail.
 void
 npy_string_free(npy_packed_static_string *str,
                 npy_string_allocator *allocator);
 
 // Copies the contents of *in* into *out*. Allocates a new string buffer for
-// *out* and assumes that *out* is uninitialized. Returns -1 if malloc fails
-// and -2 if *out* is not initialized. npy_string_free *must* be called before
-// this is called if *in* points to an existing string. Returns 0 on success.
+// *out*, npy_string_free *must* be called before this is called if *out*
+// points to an existing string. Returns -1 if malloc fails. Returns 0 on
+// success.
 int
 npy_string_dup(const npy_packed_static_string *in,
                npy_packed_static_string *out, npy_string_allocator *allocator);
@@ -69,20 +72,19 @@ npy_string_dup(const npy_packed_static_string *in,
 // *size* bytes of text. Does not do any initialization, the caller must
 // initialize the string buffer after this function returns. Calling
 // npy_string_free on *to_init* before calling this function on an existing
-// string or copying the contents of NPY_EMPTY_STRING into *to_init* is
-// sufficient to initialize it. Does not check if *to_init* is NULL or if the
-// internal buffer is non-NULL, undefined behavior or memory leaks are
-// possible if this function is passed a pointer to an unintialized struct,
-// a NULL pointer, or an existing heap-allocated string.  Returns 0 on
-// success. Returns -1 if allocating the string would exceed the maximum
-// allowed string size or exhaust available memory. Returns 0 on success.
+// string or initializing a new string with the contents of NPY_EMPTY_STRING
+// is sufficient to initialize it. Does not check if *to_init* has already
+// been initialized or if the internal buffer is non-NULL, undefined behavior
+// or memory leaks are possible if this function is passed a NULL pointer or
+// an existing heap-allocated string.  Returns 0 on success. Returns -1 if
+// allocating the string would exceed the maximum allowed string size or
+// exhaust available memory. Returns 0 on success.
 int
 npy_string_newemptysize(size_t size, npy_packed_static_string *out,
                         npy_string_allocator *allocator);
 
-// Determine if *in* corresponds to a NULL npy_static_string struct (e.g. len
-// is zero and buf is NULL. Returns 1 if this is the case and zero otherwise.
-// Cannot fail.
+// Determine if *in* corresponds to a NULL npy_static_string struct. Returns 1
+// if this is the case and zero otherwise.  Cannot fail.
 int
 npy_string_isnull(const npy_packed_static_string *in);
 
@@ -91,10 +93,22 @@ npy_string_isnull(const npy_packed_static_string *in);
 int
 npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2);
 
+// Extract the packed contents of *packed_string* into *unpacked_string*.  A
+// useful pattern is to define a stack-allocated npy_static_string instance
+// initialized to {0, NULL} and pass a pointer to that string to unpack the
+// contents of a packed string. The *unpacked_string* is a read-only view onto
+// the *packed_string* data and should not be used to modify the string
+// data. If *packed_string* is the null string, sets *unpacked_string* to the
+// NULL pointer. Returns 1 if *packed_string* is the null string and 0
+// otherwise so this function can be used to simultaneously unpack a string
+// and determine if it is a null string.
 int
 npy_load_string(const npy_packed_static_string *packed_string,
                 npy_static_string *unpacked_string);
 
+// Returns the size of the string data in the packed string. Useful in
+// situations where only the string size is needed and determing if this is a
+// null or unpacking the string is unnecessary.
 size_t
 npy_string_size(const npy_packed_static_string *packed_string);
 

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -22,7 +22,7 @@ extern const npy_packed_static_string *NPY_EMPTY_STRING;
 extern const npy_packed_static_string *NPY_NULL_STRING;
 
 // one byte in size is reserved for flags and small string optimization
-#define NPY_MAX_STRING_SIZE (1 << (sizeof(size_t) - 1)) - 1
+#define NPY_MAX_STRING_SIZE ((int64_t)1 << 8 * (sizeof(size_t) - 1)) - 1
 
 // Handles heap allocations for static strings.
 typedef struct npy_string_allocator npy_string_allocator;

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -17,7 +17,7 @@ typedef struct npy_static_string {
 // npy_static_string API functions.
 extern const npy_packed_static_string *NPY_EMPTY_STRING;
 // Represents a sentinel value, use npy_string_isnull or the return value of
-// npy_load_string to check if a value is null before working with the unpacked
+// npy_string_load to check if a value is null before working with the unpacked
 // representation.
 extern const npy_packed_static_string *NPY_NULL_STRING;
 
@@ -113,7 +113,7 @@ npy_string_cmp(const npy_static_string *s1, const npy_static_string *s2);
 // string, and returns 0 otherwise. This function can be used to
 // simultaneously unpack a string and determine if it is a null string.
 int
-npy_load_string(npy_string_allocator *allocator,
+npy_string_load(npy_string_allocator *allocator,
                 const npy_packed_static_string *packed_string,
                 npy_static_string *unpacked_string);
 

--- a/stringdtype/stringdtype/src/static_string.h
+++ b/stringdtype/stringdtype/src/static_string.h
@@ -2,7 +2,6 @@
 #define _NPY_STATIC_STRING_H
 
 #include "stdlib.h"
-#include "string.h"
 
 typedef struct npy_packed_static_string {
     char packed_buffer[sizeof(char *) + sizeof(size_t)];
@@ -13,16 +12,28 @@ typedef struct npy_static_string {
     const char *buf;
 } npy_static_string;
 
-// represents the empty string and can be passed safely to npy_static_string
-// API functions
+// Represents the empty string. The unpacked string can be passed safely to
+// npy_static_string API functions.
 extern const npy_packed_static_string *NPY_EMPTY_STRING;
-// represents a sentinel value, *CANNOT* be passed safely to npy_static_string
-// API functions, use npy_string_isnull to check if a value is null before
-// working with it.
+// Represents a sentinel value, use npy_string_isnull or the return value of
+// npy_load_string to check if a value is null before working with the unpacked
+// representation.
 extern const npy_packed_static_string *NPY_NULL_STRING;
 
 // one byte in size is reserved for flags and small string optimization
 #define NPY_MAX_STRING_SIZE (1 << (sizeof(size_t) - 1)) - 1
+
+// Handles heap allocations for static strings.
+typedef struct npy_string_allocator npy_string_allocator;
+
+typedef void *(*npy_string_malloc_func)(size_t size);
+typedef void (*npy_string_free_func)(void *ptr);
+
+// Use these functions to create a new allocator and destroy allocators
+npy_string_allocator *
+npy_string_new_allocator(npy_string_malloc_func m, npy_string_free_func f);
+void
+npy_string_free_allocator(npy_string_allocator *allocator);
 
 // Allocates a new buffer for *to_init*, which must be set to NULL before
 // calling this function, filling the newly allocated buffer with the copied
@@ -37,12 +48,14 @@ extern const npy_packed_static_string *NPY_NULL_STRING;
 // allowed string size or exhaust available memory. Returns 0 on success.
 int
 npy_string_newsize(const char *init, size_t size,
-                   npy_packed_static_string *to_init);
+                   npy_packed_static_string *to_init,
+                   npy_string_allocator *allocator);
 
 // Sets len to 0 and if the internal buffer is not already NULL, frees it if
 // it is allocated on the heap and sets it to NULL. Cannot fail.
 void
-npy_string_free(npy_packed_static_string *str);
+npy_string_free(npy_packed_static_string *str,
+                npy_string_allocator *allocator);
 
 // Copies the contents of *in* into *out*. Allocates a new string buffer for
 // *out* and assumes that *out* is uninitialized. Returns -1 if malloc fails
@@ -50,21 +63,22 @@ npy_string_free(npy_packed_static_string *str);
 // this is called if *in* points to an existing string. Returns 0 on success.
 int
 npy_string_dup(const npy_packed_static_string *in,
-               npy_packed_static_string *out);
+               npy_packed_static_string *out, npy_string_allocator *allocator);
 
 // Allocates a new string buffer for *out* with enough capacity to store
 // *size* bytes of text. Does not do any initialization, the caller must
 // initialize the string buffer after this function returns. Calling
 // npy_string_free on *to_init* before calling this function on an existing
 // string or copying the contents of NPY_EMPTY_STRING into *to_init* is
-// sufficient to initialize it.Does not check if *to_init* is NULL or if the
+// sufficient to initialize it. Does not check if *to_init* is NULL or if the
 // internal buffer is non-NULL, undefined behavior or memory leaks are
-// possible if this function is passed a pointer to a an unintialized struct,
+// possible if this function is passed a pointer to an unintialized struct,
 // a NULL pointer, or an existing heap-allocated string.  Returns 0 on
 // success. Returns -1 if allocating the string would exceed the maximum
 // allowed string size or exhaust available memory. Returns 0 on success.
 int
-npy_string_newemptysize(size_t size, npy_packed_static_string *out);
+npy_string_newemptysize(size_t size, npy_packed_static_string *out,
+                        npy_string_allocator *allocator);
 
 // Determine if *in* corresponds to a NULL npy_static_string struct (e.g. len
 // is zero and buf is NULL. Returns 1 if this is the case and zero otherwise.

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -57,7 +57,7 @@ multiply_resolve_descriptors(
                           "Failed to deallocate string in multiply");        \
                 return -1;                                                   \
             }                                                                \
-            int is_isnull = npy_load_string(idescr->allocator, ips, &is);    \
+            int is_isnull = npy_string_load(idescr->allocator, ips, &is);    \
             if (is_isnull == -1) {                                           \
                 gil_error(PyExc_MemoryError,                                 \
                           "Failed to load string in multiply");              \
@@ -94,7 +94,7 @@ multiply_resolve_descriptors(
             }                                                                \
                                                                              \
             npy_static_string os = {0, NULL};                                \
-            int is_null = npy_load_string(odescr->allocator, ops, &os);      \
+            int is_null = npy_string_load(odescr->allocator, ops, &os);      \
             if (is_null == -1) {                                             \
                 gil_error(PyExc_MemoryError,                                 \
                           "Failed to load string in string multiply");       \
@@ -259,10 +259,10 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(s1descr->allocator, ps1, &s1);
+        int s1_isnull = npy_string_load(s1descr->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(s2descr->allocator, ps2, &s2);
+        int s2_isnull = npy_string_load(s2descr->allocator, ps2, &s2);
         if (s1_isnull == -1 || s2_isnull == -1) {
             gil_error(PyExc_MemoryError, "Failed to load string in add");
             return -1;
@@ -307,7 +307,7 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
 
         npy_static_string os = {0, NULL};
 
-        if (npy_load_string(odescr->allocator, ops, &os) < 0) {
+        if (npy_string_load(odescr->allocator, ops, &os) < 0) {
             gil_error(PyExc_MemoryError, "Failed to load string in add");
         };
 
@@ -442,10 +442,10 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
+        int s1_isnull = npy_string_load(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        int s2_isnull = npy_string_load(descr2->allocator, ps2, &s2);
         if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
             gil_error(PyExc_MemoryError, "Failed to load string in equal");
             return -1;
@@ -513,10 +513,10 @@ string_not_equal_strided_loop(PyArrayMethod_Context *context,
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
+        int s1_isnull = npy_string_load(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        int s2_isnull = npy_string_load(descr2->allocator, ps2, &s2);
         if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
             gil_error(PyExc_MemoryError, "Failed to load string in not equal");
             return -1;
@@ -584,10 +584,10 @@ string_greater_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
+        int s1_isnull = npy_string_load(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        int s2_isnull = npy_string_load(descr2->allocator, ps2, &s2);
         if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
             gil_error(PyExc_MemoryError, "Failed to load string in greater");
             return -1;
@@ -653,10 +653,10 @@ string_greater_equal_strided_loop(PyArrayMethod_Context *context,
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
+        int s1_isnull = npy_string_load(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        int s2_isnull = npy_string_load(descr2->allocator, ps2, &s2);
         if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in greater equal");
@@ -721,10 +721,10 @@ string_less_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
+        int s1_isnull = npy_string_load(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        int s2_isnull = npy_string_load(descr2->allocator, ps2, &s2);
         if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
             gil_error(PyExc_MemoryError, "Failed to load string in less");
             return -1;
@@ -789,10 +789,10 @@ string_less_equal_strided_loop(PyArrayMethod_Context *context,
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
+        int s1_isnull = npy_string_load(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        int s2_isnull = npy_string_load(descr2->allocator, ps2, &s2);
         if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in less equal");

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -13,12 +13,8 @@ multiply_resolve_descriptors(
 {
     PyArray_Descr *ldescr = given_descrs[0];
     PyArray_Descr *rdescr = given_descrs[1];
-    Py_INCREF(ldescr);
-    loop_descrs[0] = ldescr;
-    Py_INCREF(rdescr);
-    loop_descrs[1] = rdescr;
-
     StringDTypeObject *odescr = NULL;
+    PyArray_Descr *out_descr = NULL;
 
     if (dtypes[0] == (PyArray_DTypeMeta *)&StringDType) {
         odescr = (StringDTypeObject *)ldescr;
@@ -27,8 +23,18 @@ multiply_resolve_descriptors(
         odescr = (StringDTypeObject *)rdescr;
     }
 
-    loop_descrs[2] = (PyArray_Descr *)new_stringdtype_instance(
-            odescr->na_object, odescr->coerce);
+    out_descr = (PyArray_Descr *)new_stringdtype_instance(odescr->na_object,
+                                                          odescr->coerce);
+
+    if (out_descr == NULL) {
+        return (NPY_CASTING)-1;
+    }
+
+    Py_INCREF(ldescr);
+    loop_descrs[0] = ldescr;
+    Py_INCREF(rdescr);
+    loop_descrs[1] = rdescr;
+    loop_descrs[2] = out_descr;
 
     return NPY_NO_CASTING;
 }
@@ -39,16 +45,25 @@ multiply_resolve_descriptors(
             npy_intp i_stride, npy_intp o_stride, int has_null,              \
             int has_nan_na, int has_string_na,                               \
             const npy_static_string *default_string,                         \
-            npy_string_allocator *allocator)                                 \
+            StringDTypeObject *idescr, StringDTypeObject *odescr)            \
     {                                                                        \
         while (N--) {                                                        \
             const npy_packed_static_string *ips =                            \
                     (npy_packed_static_string *)sin;                         \
             npy_static_string is = {0, NULL};                                \
             npy_packed_static_string *ops = (npy_packed_static_string *)out; \
-            npy_string_free(ops, allocator);                                 \
-            int is_isnull = npy_load_string(ips, &is);                       \
-            if (is_isnull) {                                                 \
+            if (npy_string_free(ops, odescr->allocator) < 0) {               \
+                gil_error(PyExc_MemoryError,                                 \
+                          "Failed to deallocate string in multiply");        \
+                return -1;                                                   \
+            }                                                                \
+            int is_isnull = npy_load_string(idescr->allocator, ips, &is);    \
+            if (is_isnull == -1) {                                           \
+                gil_error(PyExc_MemoryError,                                 \
+                          "Failed to load string in multiply");              \
+                return -1;                                                   \
+            }                                                                \
+            else if (is_isnull) {                                            \
                 if (has_nan_na) {                                            \
                     *ops = *NPY_NULL_STRING;                                 \
                     sin += s_stride;                                         \
@@ -71,14 +86,20 @@ multiply_resolve_descriptors(
             size_t newsize = cursize * factor;                               \
             /* newsize can only be less than cursize if there is overflow */ \
             if (((newsize < cursize) ||                                      \
-                 npy_string_newemptysize(newsize, ops, allocator) < 0)) {    \
+                 npy_string_newemptysize(newsize, ops, odescr->allocator) <  \
+                         0)) {                                               \
                 gil_error(PyExc_MemoryError,                                 \
                           "Failed to allocate string in string mutiply");    \
                 return -1;                                                   \
             }                                                                \
                                                                              \
             npy_static_string os = {0, NULL};                                \
-            npy_load_string(ops, &os);                                       \
+            int is_null = npy_load_string(odescr->allocator, ops, &os);      \
+            if (is_null == -1) {                                             \
+                gil_error(PyExc_MemoryError,                                 \
+                          "Failed to load string in string multiply");       \
+                return -1;                                                   \
+            }                                                                \
             for (size_t i = 0; i < (size_t)factor; i++) {                    \
                 /* excplicitly discard const; initializing new buffer */     \
                 /* multiply can't overflow because cursize * factor */       \
@@ -98,13 +119,14 @@ multiply_resolve_descriptors(
             npy_intp const dimensions[], npy_intp const strides[],           \
             NpyAuxData *NPY_UNUSED(auxdata))                                 \
     {                                                                        \
-        StringDTypeObject *descr =                                           \
+        StringDTypeObject *idescr =                                          \
                 (StringDTypeObject *)context->descriptors[0];                \
-        int has_null = descr->na_object != NULL;                             \
-        int has_nan_na = descr->has_nan_na;                                  \
-        int has_string_na = descr->has_string_na;                            \
-        const npy_static_string *default_string = &descr->default_string;    \
-        npy_string_allocator *allocator = descr->allocator;                  \
+        StringDTypeObject *odescr =                                          \
+                (StringDTypeObject *)context->descriptors[2];                \
+        int has_null = odescr->na_object != NULL;                            \
+        int has_nan_na = odescr->has_nan_na;                                 \
+        int has_string_na = odescr->has_string_na;                           \
+        const npy_static_string *default_string = &idescr->default_string;   \
         npy_intp N = dimensions[0];                                          \
         char *in1 = data[0];                                                 \
         char *in2 = data[1];                                                 \
@@ -115,8 +137,8 @@ multiply_resolve_descriptors(
                                                                              \
         return multiply_loop_core_##shortname(                               \
                 N, in1, in2, out, in1_stride, in2_stride, out_stride,        \
-                has_null, has_nan_na, has_string_na, default_string,         \
-                allocator);                                                  \
+                has_null, has_nan_na, has_string_na, default_string, idescr, \
+                odescr);                                                     \
     }                                                                        \
                                                                              \
     static int multiply_left_##shortname##_strided_loop(                     \
@@ -124,13 +146,14 @@ multiply_resolve_descriptors(
             npy_intp const dimensions[], npy_intp const strides[],           \
             NpyAuxData *NPY_UNUSED(auxdata))                                 \
     {                                                                        \
-        StringDTypeObject *descr =                                           \
+        StringDTypeObject *idescr =                                          \
                 (StringDTypeObject *)context->descriptors[1];                \
-        int has_null = descr->na_object != NULL;                             \
-        int has_nan_na = descr->has_nan_na;                                  \
-        int has_string_na = descr->has_string_na;                            \
-        const npy_static_string *default_string = &descr->default_string;    \
-        npy_string_allocator *allocator = descr->allocator;                  \
+        StringDTypeObject *odescr =                                          \
+                (StringDTypeObject *)context->descriptors[2];                \
+        int has_null = idescr->na_object != NULL;                            \
+        int has_nan_na = idescr->has_nan_na;                                 \
+        int has_string_na = idescr->has_string_na;                           \
+        const npy_static_string *default_string = &idescr->default_string;   \
         npy_intp N = dimensions[0];                                          \
         char *in1 = data[0];                                                 \
         char *in2 = data[1];                                                 \
@@ -141,8 +164,8 @@ multiply_resolve_descriptors(
                                                                              \
         return multiply_loop_core_##shortname(                               \
                 N, in2, in1, out, in2_stride, in1_stride, out_stride,        \
-                has_null, has_nan_na, has_string_na, default_string,         \
-                allocator);                                                  \
+                has_null, has_nan_na, has_string_na, default_string, idescr, \
+                odescr);                                                     \
     }
 
 MULTIPLY_IMPL(int8);
@@ -177,11 +200,12 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
                            PyArray_Descr *loop_descrs[],
                            npy_intp *NPY_UNUSED(view_offset))
 {
-    PyObject *na_obj1 = ((StringDTypeObject *)given_descrs[0])->na_object;
-    PyObject *na_obj2 = ((StringDTypeObject *)given_descrs[1])->na_object;
+    StringDTypeObject *descr1 = (StringDTypeObject *)given_descrs[0];
+    StringDTypeObject *descr2 = (StringDTypeObject *)given_descrs[1];
 
     // RichCompareBool has a short-circuit pointer comparison fast path.
-    int eq_res = PyObject_RichCompareBool(na_obj1, na_obj2, Py_EQ);
+    int eq_res = _eq_comparison(descr1->coerce, descr2->coerce,
+                                descr1->na_object, descr2->na_object);
 
     if (eq_res < 0) {
         return (NPY_CASTING)-1;
@@ -189,8 +213,8 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 
     if (eq_res != 1) {
         PyErr_SetString(PyExc_TypeError,
-                        "Can only do binary operations with StringDType "
-                        "instances that share an na_object.");
+                        "Can only do binary operations with equal StringDType "
+                        "instances.");
         return (NPY_CASTING)-1;
     }
 
@@ -198,8 +222,16 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
     loop_descrs[0] = given_descrs[0];
     Py_INCREF(given_descrs[1]);
     loop_descrs[1] = given_descrs[1];
-    Py_INCREF(given_descrs[1]);
-    loop_descrs[2] = given_descrs[1];
+
+    PyArray_Descr *out_descr = (PyArray_Descr *)new_stringdtype_instance(
+            ((StringDTypeObject *)given_descrs[1])->na_object,
+            ((StringDTypeObject *)given_descrs[1])->coerce);
+
+    if (out_descr == NULL) {
+        return (NPY_CASTING)-1;
+    }
+
+    loop_descrs[2] = out_descr;
 
     return NPY_NO_CASTING;
 }
@@ -209,12 +241,13 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
                  npy_intp const dimensions[], npy_intp const strides[],
                  NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
-    npy_string_allocator *allocator = descr->allocator;
+    StringDTypeObject *s1descr = (StringDTypeObject *)context->descriptors[0];
+    StringDTypeObject *s2descr = (StringDTypeObject *)context->descriptors[1];
+    StringDTypeObject *odescr = (StringDTypeObject *)context->descriptors[2];
+    int has_null = s1descr->na_object != NULL;
+    int has_nan_na = s1descr->has_nan_na;
+    int has_string_na = s1descr->has_string_na;
+    const npy_static_string *default_string = &s1descr->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -226,12 +259,19 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(ps1, &s1);
+        int s1_isnull = npy_load_string(s1descr->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(ps2, &s2);
+        int s2_isnull = npy_load_string(s2descr->allocator, ps2, &s2);
+        if (s1_isnull == -1 || s2_isnull == -1) {
+            gil_error(PyExc_MemoryError, "Failed to load string in add");
+            return -1;
+        }
         npy_packed_static_string *ops = (npy_packed_static_string *)out;
-        npy_string_free(ops, allocator);
+        if (npy_string_free(ops, odescr->allocator) < 0) {
+            gil_error(PyExc_MemoryError, "Failed to deallocate string in add");
+            return -1;
+        }
         if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
                 *ops = *NPY_NULL_STRING;
@@ -256,15 +296,20 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
             // overflow
             gil_error(PyExc_MemoryError,
                       "Failed to allocate string in string add");
+            return -1;
         }
 
-        if (npy_string_newemptysize(s1.size + s2.size, ops, allocator) < 0) {
+        if (npy_string_newemptysize(s1.size + s2.size, ops,
+                                    odescr->allocator) < 0) {
+            gil_error(PyExc_MemoryError, "Failed to allocate string in add");
             return -1;
         }
 
         npy_static_string os = {0, NULL};
 
-        npy_load_string(ops, &os);
+        if (npy_load_string(odescr->allocator, ops, &os) < 0) {
+            gil_error(PyExc_MemoryError, "Failed to load string in add");
+        };
 
         // explicitly discard const because we're initializing empty buffers
         memcpy((char *)os.buf, s1.buf, s1.size);
@@ -283,8 +328,12 @@ maximum_strided_loop(PyArrayMethod_Context *context, char *const data[],
                      npy_intp const dimensions[], npy_intp const strides[],
                      NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    npy_string_allocator *allocator = descr->allocator;
+    StringDTypeObject *in1_descr =
+            ((StringDTypeObject *)context->descriptors[0]);
+    StringDTypeObject *in2_descr =
+            ((StringDTypeObject *)context->descriptors[1]);
+    StringDTypeObject *out_descr =
+            ((StringDTypeObject *)context->descriptors[2]);
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -297,20 +346,20 @@ maximum_strided_loop(PyArrayMethod_Context *context, char *const data[],
         const npy_packed_static_string *sin1 = (npy_packed_static_string *)in1;
         const npy_packed_static_string *sin2 = (npy_packed_static_string *)in2;
         npy_packed_static_string *sout = (npy_packed_static_string *)out;
-        if (_compare(in1, in2, descr) > 0) {
+        if (_compare(in1, in2, in1_descr, in2_descr) > 0) {
             // Only copy *out* to *in1* if they point to different locations;
-            // for *arr.max()* they point to the same address.
+            // for *arr.max()* they can point to the same address.
             if (in1 != out) {
-                npy_string_free(sout, allocator);
-                if (npy_string_dup(sin1, sout, allocator) < 0) {
+                if (free_and_copy(in1_descr->allocator, out_descr->allocator,
+                                  sin1, sout, "maximum") == -1) {
                     return -1;
                 }
             }
         }
         else {
             if (in2 != out) {
-                npy_string_free(sout, allocator);
-                if (npy_string_dup(sin2, sout, allocator) < 0) {
+                if (free_and_copy(in2_descr->allocator, out_descr->allocator,
+                                  sin2, sout, "maximum") == -1) {
                     return -1;
                 }
             }
@@ -328,8 +377,12 @@ minimum_strided_loop(PyArrayMethod_Context *context, char *const data[],
                      npy_intp const dimensions[], npy_intp const strides[],
                      NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    npy_string_allocator *allocator = descr->allocator;
+    StringDTypeObject *in1_descr =
+            ((StringDTypeObject *)context->descriptors[0]);
+    StringDTypeObject *in2_descr =
+            ((StringDTypeObject *)context->descriptors[1]);
+    StringDTypeObject *out_descr =
+            ((StringDTypeObject *)context->descriptors[2]);
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -342,18 +395,18 @@ minimum_strided_loop(PyArrayMethod_Context *context, char *const data[],
         const npy_packed_static_string *sin1 = (npy_packed_static_string *)in1;
         const npy_packed_static_string *sin2 = (npy_packed_static_string *)in2;
         npy_packed_static_string *sout = (npy_packed_static_string *)out;
-        if (_compare(in1, in2, descr) < 0) {
+        if (_compare(in1, in2, in1_descr, in2_descr) < 0) {
             if (in1 != out) {
-                npy_string_free(sout, allocator);
-                if (npy_string_dup(sin1, sout, allocator) < 0) {
+                if (free_and_copy(in1_descr->allocator, out_descr->allocator,
+                                  sin1, sout, "minimum") == -1) {
                     return -1;
                 }
             }
         }
         else {
             if (in2 != out) {
-                npy_string_free(sout, allocator);
-                if (npy_string_dup(sin2, sout, allocator) < 0) {
+                if (free_and_copy(in2_descr->allocator, out_descr->allocator,
+                                  sin2, sout, "minimum") == -1) {
                     return -1;
                 }
             }
@@ -372,11 +425,12 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
                           npy_intp const strides[],
                           NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
+    StringDTypeObject *descr1 = (StringDTypeObject *)context->descriptors[0];
+    StringDTypeObject *descr2 = (StringDTypeObject *)context->descriptors[1];
+    int has_null = descr1->na_object != NULL;
+    int has_nan_na = descr1->has_nan_na;
+    int has_string_na = descr1->has_string_na;
+    const npy_static_string *default_string = &descr1->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -388,11 +442,15 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(ps1, &s1);
+        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(ps2, &s2);
-        if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
+        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
+            gil_error(PyExc_MemoryError, "Failed to load string in equal");
+            return -1;
+        }
+        else if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
                 // s1 or s2 is NA
                 *out = (npy_bool)0;
@@ -415,7 +473,8 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
                 }
             }
         }
-        if (s1.size == s2.size && strncmp(s1.buf, s2.buf, s1.size) == 0) {
+        if (s1.size == s2.size &&
+            (s1.size == 0 || strncmp(s1.buf, s2.buf, s1.size) == 0)) {
             *out = (npy_bool)1;
         }
         else {
@@ -437,11 +496,12 @@ string_not_equal_strided_loop(PyArrayMethod_Context *context,
                               npy_intp const strides[],
                               NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
+    StringDTypeObject *descr1 = (StringDTypeObject *)context->descriptors[0];
+    StringDTypeObject *descr2 = (StringDTypeObject *)context->descriptors[1];
+    int has_null = descr1->na_object != NULL;
+    int has_nan_na = descr1->has_nan_na;
+    int has_string_na = descr1->has_string_na;
+    const npy_static_string *default_string = &descr1->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -453,11 +513,15 @@ string_not_equal_strided_loop(PyArrayMethod_Context *context,
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(ps1, &s1);
+        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(ps2, &s2);
-        if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
+        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
+            gil_error(PyExc_MemoryError, "Failed to load string in not equal");
+            return -1;
+        }
+        else if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
                 // s1 or s2 is NA
                 *out = (npy_bool)0;
@@ -503,11 +567,12 @@ string_greater_strided_loop(PyArrayMethod_Context *context, char *const data[],
                             npy_intp const strides[],
                             NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
+    StringDTypeObject *descr1 = (StringDTypeObject *)context->descriptors[0];
+    StringDTypeObject *descr2 = (StringDTypeObject *)context->descriptors[1];
+    int has_null = descr1->na_object != NULL;
+    int has_nan_na = descr1->has_nan_na;
+    int has_string_na = descr1->has_string_na;
+    const npy_static_string *default_string = &descr1->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -519,11 +584,15 @@ string_greater_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(ps1, &s1);
+        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(ps2, &s2);
-        if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
+        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
+            gil_error(PyExc_MemoryError, "Failed to load string in greater");
+            return -1;
+        }
+        else if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
                 // s1 or s2 is NA
                 *out = (npy_bool)0;
@@ -567,11 +636,12 @@ string_greater_equal_strided_loop(PyArrayMethod_Context *context,
                                   npy_intp const strides[],
                                   NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
+    StringDTypeObject *descr1 = (StringDTypeObject *)context->descriptors[0];
+    StringDTypeObject *descr2 = (StringDTypeObject *)context->descriptors[1];
+    int has_null = descr1->na_object != NULL;
+    int has_nan_na = descr1->has_nan_na;
+    int has_string_na = descr1->has_string_na;
+    const npy_static_string *default_string = &descr1->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -583,11 +653,16 @@ string_greater_equal_strided_loop(PyArrayMethod_Context *context,
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(ps1, &s1);
+        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(ps2, &s2);
-        if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
+        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
+            gil_error(PyExc_MemoryError,
+                      "Failed to load string in greater equal");
+            return -1;
+        }
+        else if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
                 // s1 or s2 is NA
                 *out = (npy_bool)0;
@@ -629,11 +704,12 @@ string_less_strided_loop(PyArrayMethod_Context *context, char *const data[],
                          npy_intp const dimensions[], npy_intp const strides[],
                          NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
+    StringDTypeObject *descr1 = (StringDTypeObject *)context->descriptors[0];
+    StringDTypeObject *descr2 = (StringDTypeObject *)context->descriptors[1];
+    int has_null = descr1->na_object != NULL;
+    int has_nan_na = descr1->has_nan_na;
+    int has_string_na = descr1->has_string_na;
+    const npy_static_string *default_string = &descr1->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -645,11 +721,15 @@ string_less_strided_loop(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(ps1, &s1);
+        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(ps2, &s2);
-        if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
+        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
+            gil_error(PyExc_MemoryError, "Failed to load string in less");
+            return -1;
+        }
+        else if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
                 // s1 or s2 is NA
                 *out = (npy_bool)0;
@@ -692,11 +772,12 @@ string_less_equal_strided_loop(PyArrayMethod_Context *context,
                                npy_intp const strides[],
                                NpyAuxData *NPY_UNUSED(auxdata))
 {
-    StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
+    StringDTypeObject *descr1 = (StringDTypeObject *)context->descriptors[0];
+    StringDTypeObject *descr2 = (StringDTypeObject *)context->descriptors[1];
+    int has_null = descr1->na_object != NULL;
+    int has_nan_na = descr1->has_nan_na;
+    int has_string_na = descr1->has_string_na;
+    const npy_static_string *default_string = &descr1->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -708,11 +789,16 @@ string_less_equal_strided_loop(PyArrayMethod_Context *context,
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
         npy_static_string s1 = {0, NULL};
-        int s1_isnull = npy_load_string(ps1, &s1);
+        int s1_isnull = npy_load_string(descr1->allocator, ps1, &s1);
         const npy_packed_static_string *ps2 = (npy_packed_static_string *)in2;
         npy_static_string s2 = {0, NULL};
-        int s2_isnull = npy_load_string(ps2, &s2);
-        if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
+        int s2_isnull = npy_load_string(descr2->allocator, ps2, &s2);
+        if (NPY_UNLIKELY(s1_isnull < 0 || s2_isnull < 0)) {
+            gil_error(PyExc_MemoryError,
+                      "Failed to load string in less equal");
+            return -1;
+        }
+        else if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
                 // s1 or s2 is NA
                 *out = (npy_bool)0;

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -747,6 +747,7 @@ def test_null_roundtripping(dtype):
     assert data[1] == arr[1]
 
 
+@pytest.mark.xfail(strict=True)
 def test_string_too_large_error():
     arr = np.array(["a", "b", "c"], dtype=StringDType())
     with pytest.raises(MemoryError):

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -17,7 +17,7 @@ from stringdtype import StringDType, StringScalar, _memory_usage
 
 @pytest.fixture
 def string_list():
-    return ["abc", "def", "ghi", "A¢☃€ 😊", "Abc", "DEF"]
+    return ["abc", "def", "ghi" * 10, "A¢☃€ 😊", "Abc", "DEF"]
 
 
 pd_param = pytest.param(
@@ -343,6 +343,13 @@ def test_pickle(dtype, string_list):
     "strings",
     [
         ["left", "right", "leftovers", "righty", "up", "down"],
+        [
+            "left" * 10,
+            "right" * 10,
+            "leftovers" * 10,
+            "righty" * 10,
+            "up" * 10,
+        ],
         ["🤣🤣", "🤣", "📵", "😰"],
         ["🚜", "🙃", "😾"],
         ["😹", "🚠", "🚌"],

--- a/unytdtype/unytdtype/src/unytdtype_main.c
+++ b/unytdtype/unytdtype/src/unytdtype_main.c
@@ -21,7 +21,7 @@ PyInit__unytdtype_main(void)
     if (_import_array() < 0) {
         return NULL;
     }
-    if (import_experimental_dtype_api(14) < 0) {
+    if (import_experimental_dtype_api(15) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
This refactors the implementation to use an arena allocator.

The `StringDTypeObject` struct gains two new fields: `int array_owned` and `npy_string_allocator *allocator`. The `array_owned` flag is used to indicate if an array owns the descriptor or not and the `allocator` is used to mediate heap memory access and allocation.

The main new feature here is that newly created arrays store data in a contiguous buffer that lives inside an `npy_string_arena` struct (that itself is an attribute of the `allocator` struct). There's only one arena per dtype instance - as declared with the `NPY_DT_UNIQUE_ARRAY_DESCRIPTOR` flag on the DType with bookeeping managed via the `array_owned` flag.

The allocator and arena structs look like this:

```C

typedef struct npy_string_arena {
    size_t cursor;
    size_t size;
    char *buffer;
} npy_string_arena;

typedef void *(*npy_string_malloc_func)(size_t size);
typedef void (*npy_string_free_func)(void *ptr);
typedef void *(*npy_string_realloc_func)(void *ptr, size_t size);

struct npy_string_allocator {
    npy_string_malloc_func malloc;
    npy_string_free_func free;
    npy_string_realloc_func realloc;
    npy_string_arena arena;
};
```

Heap-allocated string data lives in `allocator->arena->buffer`. Internally the buffer works by prepending each string allocation with a field indicating the size of the string. Right now it's always a `size_t`, but that adds a lot of overhead for small strings (alignment makes it worse) so I'd like to add a mode where small heap strings have lengths stored in a `char` or `unsigned char`.

Another nice aspect of this is now packed heap strings that are in the arena don't store a memory address directly, instead they now store an offset into the arena.

I still have it set up so that if you modify an existing string and the modification would exceed the available space to store that string, the modified string is allocated on the heap using malloc/free directly.

The bookeeping for this is mediated via the new `NPY_STRING_ARENA_FREED` and `NPY_STRING_ON_HEAP` flags. The former indicates a packed string that is freed but not yet overwritten. The latter indicates a packed string that corresponds to a string allocated directly on the heap, outside the arena buffer. Unfortunately this uses up the two unused flag bits we had available, although we still have four flags available for non-short strings.