### PR TITLE
Add a medium length string mode

### DIFF
--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -314,7 +314,8 @@ heap_or_arena_allocate(npy_string_allocator *allocator,
         }
         else {
             // not necessarily memory-aligned, so need to use memcpy
-            memcpy(&alloc_size, ((size_t *)buf - 1), sizeof(size_t));
+            char *size_loc = (char *)((uintptr_t)buf - sizeof(size_t));
+            memcpy(&alloc_size, size_loc, sizeof(size_t));
         }
         if (size <= alloc_size) {
             // we have room!

--- a/stringdtype/stringdtype/src/static_string.c
+++ b/stringdtype/stringdtype/src/static_string.c
@@ -50,8 +50,7 @@ typedef union _npy_static_string_u {
 // short string sizes fit in a 4-bit integer
 #define NPY_SHORT_STRING_SIZE_MASK 0x0F  // 0000 1111
 #define NPY_SHORT_STRING_MAX_SIZE \
-    (sizeof(npy_static_string) - 1)  // 15 or 7 depending on arch
-// one bit is used to signal a medium string
+    (sizeof(npy_static_string) - 1)      // 15 or 7 depending on arch
 #define NPY_MEDIUM_STRING_MAX_SIZE 0xFF  // 256
 
 // Since this has no flags set, technically this is a heap-allocated string

--- a/stringdtype/tests/test_char.py
+++ b/stringdtype/tests/test_char.py
@@ -4,7 +4,12 @@ from numpy.testing import assert_array_equal
 
 from stringdtype import StringDType
 
-TEST_DATA = ["hello", "Ae¢☃€ 😊", "entry\nwith\nnewlines", "entry\twith\ttabs"]
+TEST_DATA = [
+    "hello" * 10,
+    "Ae¢☃€ 😊" * 100,
+    "entry\nwith\nnewlines",
+    "entry\twith\ttabs",
+]
 
 
 @pytest.fixture
@@ -94,11 +99,11 @@ def test_binary(string_array, unicode_array, function_name, args):
 
 
 def test_strip(string_array, unicode_array):
-    rjs = np.char.rjust(string_array, 25)
-    rju = np.char.rjust(unicode_array, 25)
+    rjs = np.char.rjust(string_array, 1000)
+    rju = np.char.rjust(unicode_array, 1000)
 
-    ljs = np.char.ljust(string_array, 25)
-    lju = np.char.ljust(unicode_array, 25)
+    ljs = np.char.ljust(string_array, 1000)
+    lju = np.char.ljust(unicode_array, 1000)
 
     assert_array_equal(
         np.char.lstrip(rjs),

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -17,7 +17,7 @@ from stringdtype import StringDType, StringScalar, _memory_usage
 
 @pytest.fixture
 def string_list():
-    return ["abc", "def", "ghi" * 10, "A¢☃€ 😊", "Abc", "DEF"]
+    return ["abc", "def", "ghi" * 10, "A¢☃€ 😊" * 100, "Abc" * 1000, "DEF"]
 
 
 pd_param = pytest.param(
@@ -121,7 +121,7 @@ def test_array_creation_utf8(dtype, data):
 def test_array_creation_scalars(string_list):
     arr = np.array([StringScalar(s) for s in string_list])
     assert (
-        str(arr)
+        str(arr).replace("\n", "")
         == "[" + " ".join(["'" + str(s) + "'" for s in string_list]) + "]"
     )
     assert arr.dtype == StringDType()


### PR DESCRIPTION
This adds a "medium string" mode where the sizes of arena allocations are stored using a `char` instead of a `size_t`, saving 8 bytes per string for strings with lengths between 16 and 255 bytes. I modified the tests so they use longer strings more often which exercises all the different memory allocation modes we're now supporting.

I also dropped the attempt to store the `size_t` sizes in aligned locations because it adds a bunch of bookkeeping headaches. If it turns out the `memcpy` to unaligned addresses is slow we can come back to this.