### PR TITLE
Use a mutex to lock heap memory access

### DIFF
--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -109,15 +109,13 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(idescr);
-    NPY_STRING_RELEASE_ALLOCATOR(odescr);
+    NPY_STRING_RELEASE_ALLOCATOR2(odescr, idescr);
 
     return 0;
 
 fail:
 
-    NPY_STRING_RELEASE_ALLOCATOR(idescr);
-    NPY_STRING_RELEASE_ALLOCATOR(odescr);
+    NPY_STRING_RELEASE_ALLOCATOR2(odescr, idescr);
 
     return -1;
 }

--- a/stringdtype/stringdtype/src/casts.c
+++ b/stringdtype/stringdtype/src/casts.c
@@ -82,6 +82,8 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
     npy_intp in_stride = strides[0];
     npy_intp out_stride = strides[1];
 
+    NPY_STRING_ACQUIRE_ALLOCATOR2(odescr, idescr);
+
     while (N--) {
         const npy_packed_static_string *s = (npy_packed_static_string *)in;
         npy_packed_static_string *os = (npy_packed_static_string *)out;
@@ -94,11 +96,12 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
                     gil_error(PyExc_MemoryError,
                               "Failed to allocate string in string to string "
                               "cast.");
+                    goto fail;
                 }
             }
             else if (free_and_copy(idescr->allocator, odescr->allocator, s, os,
                                    "string to string cast") == -1) {
-                return -1;
+                goto fail;
             }
         }
 
@@ -106,7 +109,17 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(idescr);
+    NPY_STRING_RELEASE_ALLOCATOR(odescr);
+
     return 0;
+
+fail:
+
+    NPY_STRING_RELEASE_ALLOCATOR(idescr);
+    NPY_STRING_RELEASE_ALLOCATOR(odescr);
+
+    return -1;
 }
 
 static PyType_Slot s2s_slots[] = {
@@ -208,8 +221,11 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
                   NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_Descr **descrs = context->descriptors;
-    npy_string_allocator *allocator =
-            ((StringDTypeObject *)descrs[1])->allocator;
+    StringDTypeObject *sdescr = (StringDTypeObject *)descrs[1];
+
+    NPY_STRING_ACQUIRE_ALLOCATOR(sdescr);
+    npy_string_allocator *allocator = sdescr->allocator;
+
     long max_in_size = (descrs[0]->elsize) / 4;
 
     npy_intp N = dimensions[0];
@@ -226,24 +242,25 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
         if (utf8_size(in, max_in_size, &num_codepoints, &out_num_bytes) ==
             -1) {
             gil_error(PyExc_TypeError, "Invalid unicode code point found");
-            return -1;
+            goto fail;
         }
         npy_packed_static_string *out_pss = (npy_packed_static_string *)out;
         if (npy_string_free(out_pss, allocator) < 0) {
             gil_error(PyExc_MemoryError,
                       "Failed to deallocate string in unicode to string cast");
-            return -1;
+            goto fail;
         }
         if (npy_string_newemptysize(out_num_bytes, out_pss, allocator) < 0) {
             gil_error(PyExc_MemoryError,
                       "Failed to allocate string in unicode to string cast");
-            return -1;
+            goto fail;
         }
         npy_static_string out_ss = {0, NULL};
         int is_null = npy_string_load(allocator, out_pss, &out_ss);
         if (is_null == -1) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in unicode to string cast");
+            goto fail;
         }
         // ignores const to fill in the buffer
         char *out_buf = (char *)out_ss.buf;
@@ -272,7 +289,15 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(sdescr);
+
     return 0;
+
+fail:
+
+    NPY_STRING_RELEASE_ALLOCATOR(sdescr);
+
+    return -1;
 }
 
 static PyType_Slot u2s_slots[] = {{NPY_METH_resolve_descriptors,
@@ -353,6 +378,7 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
                   NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    NPY_STRING_ACQUIRE_ALLOCATOR(descr);
     npy_string_allocator *allocator = descr->allocator;
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
@@ -377,6 +403,7 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
         if (is_null == -1) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in unicode to string cast");
+            goto fail;
         }
         else if (is_null) {
             if (has_null && !has_string_na) {
@@ -419,7 +446,14 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+
     return 0;
+
+fail:
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+
+    return -1;
 }
 
 static PyType_Slot s2u_slots[] = {
@@ -458,6 +492,7 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
                NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    NPY_STRING_ACQUIRE_ALLOCATOR(descr);
     npy_string_allocator *allocator = descr->allocator;
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
@@ -477,6 +512,7 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
         if (is_null == -1) {
             gil_error(PyExc_MemoryError,
                       "Failed to load string in unicode to string cast");
+            goto fail;
         }
         else if (is_null) {
             if (has_null && !has_string_na) {
@@ -498,7 +534,15 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+
     return 0;
+
+fail:
+
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+
+    return -1;
 }
 
 static PyType_Slot s2b_slots[] = {
@@ -523,6 +567,7 @@ bool_to_string(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[1];
 
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[1];
+    NPY_STRING_ACQUIRE_ALLOCATOR(descr);
     npy_string_allocator *allocator = descr->allocator;
 
     while (N--) {
@@ -530,7 +575,7 @@ bool_to_string(PyArrayMethod_Context *context, char *const data[],
         if (npy_string_free(out_pss, allocator) < 0) {
             gil_error(PyExc_MemoryError,
                       "Failed to deallocate string in bool to string cast");
-            return -1;
+            goto fail;
         }
         char *ret_val = NULL;
         size_t size = 0;
@@ -545,20 +590,28 @@ bool_to_string(PyArrayMethod_Context *context, char *const data[],
         else {
             gil_error(PyExc_RuntimeError,
                       "invalid value encountered in bool to string cast");
-            return -1;
+            goto fail;
         }
         if (npy_string_newsize(ret_val, size, out_pss, allocator) < 0) {
             // execution should never get here because this will be a small
             // string on all platforms
             gil_error(PyExc_MemoryError,
                       "Failed to allocate string in bool to string cast");
-            return -1;
+            goto fail;
         }
         in += in_stride;
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+
     return 0;
+
+fail:
+
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+
+    return -1;
 }
 
 static PyType_Slot b2s_slots[] = {{NPY_METH_resolve_descriptors,
@@ -720,6 +773,7 @@ uint_to_string(unsigned long long in, char *out,
     {                                                                       \
         StringDTypeObject *descr =                                          \
                 ((StringDTypeObject *)context->descriptors[0]);             \
+        NPY_STRING_ACQUIRE_ALLOCATOR(descr);                                \
         npy_string_allocator *allocator = descr->allocator;                 \
         int hasnull = descr->na_object != NULL;                             \
         const npy_static_string *default_string = &descr->default_string;   \
@@ -735,23 +789,30 @@ uint_to_string(unsigned long long in, char *out,
             npy_longtype value;                                             \
             if (string_to_##typekind(in, &value, hasnull, default_string,   \
                                      allocator) != 0) {                     \
-                return -1;                                                  \
+                goto fail;                                                  \
             }                                                               \
             *out = (npy_##typename)value;                                   \
             if (*out != value) {                                            \
                 /* out of bounds, raise error following NEP 50 behavior */  \
-                PyErr_Format(PyExc_OverflowError,                           \
-                             "Integer %" #printf_code                       \
-                             " is out of bounds "                           \
-                             "for " #typename,                              \
-                             value);                                        \
-                return -1;                                                  \
+                char message[200];                                          \
+                snprintf(message, sizeof(message),                          \
+                         "Integer %" #printf_code                           \
+                         " is out of bounds "                               \
+                         "for " #typename,                                  \
+                         value);                                            \
+                gil_error(PyExc_OverflowError, message);                    \
+                goto fail;                                                  \
             }                                                               \
             in += in_stride;                                                \
             out += out_stride;                                              \
         }                                                                   \
                                                                             \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                                \
         return 0;                                                           \
+                                                                            \
+    fail:                                                                   \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                                \
+        return -1;                                                          \
     }                                                                       \
                                                                             \
     static PyType_Slot s2##shortname##_slots[] = {                          \
@@ -776,18 +837,24 @@ uint_to_string(unsigned long long in, char *out,
                                                                             \
         StringDTypeObject *descr =                                          \
                 (StringDTypeObject *)context->descriptors[1];               \
+        NPY_STRING_ACQUIRE_ALLOCATOR(descr);                                \
         npy_string_allocator *allocator = descr->allocator;                 \
                                                                             \
         while (N--) {                                                       \
             if (typekind##_to_string((longtype)*in, out, allocator) != 0) { \
-                return -1;                                                  \
+                goto fail;                                                  \
             }                                                               \
                                                                             \
             in += in_stride;                                                \
             out += out_stride;                                              \
         }                                                                   \
                                                                             \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                                \
         return 0;                                                           \
+                                                                            \
+    fail:                                                                   \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                                \
+        return -1;                                                          \
     }                                                                       \
                                                                             \
     static PyType_Slot shortname##2s_slots [] = {                           \
@@ -894,6 +961,7 @@ string_to_pyfloat(char *in, int hasnull,
     {                                                                        \
         StringDTypeObject *descr =                                           \
                 (StringDTypeObject *)context->descriptors[0];                \
+        NPY_STRING_ACQUIRE_ALLOCATOR(descr);                                 \
         npy_string_allocator *allocator = descr->allocator;                  \
         int hasnull = (descr->na_object != NULL);                            \
         const npy_static_string *default_string = &descr->default_string;    \
@@ -909,7 +977,7 @@ string_to_pyfloat(char *in, int hasnull,
             PyObject *pyfloat_value = string_to_pyfloat(                     \
                     in, hasnull, default_string, allocator);                 \
             if (pyfloat_value == NULL) {                                     \
-                return -1;                                                   \
+                goto fail;                                                   \
             }                                                                \
             double dval = PyFloat_AS_DOUBLE(pyfloat_value);                  \
             npy_##typename fval = (double_to_float)(dval);                   \
@@ -917,7 +985,7 @@ string_to_pyfloat(char *in, int hasnull,
             if (NPY_UNLIKELY(isinf_name(fval) && !(npy_isinf(dval)))) {      \
                 if (PyUFunc_GiveFloatingpointErrors("cast",                  \
                                                     NPY_FPE_OVERFLOW) < 0) { \
-                    return -1;                                               \
+                    goto fail;                                               \
                 }                                                            \
             }                                                                \
                                                                              \
@@ -927,7 +995,11 @@ string_to_pyfloat(char *in, int hasnull,
             out += out_stride;                                               \
         }                                                                    \
                                                                              \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                                 \
         return 0;                                                            \
+    fail:                                                                    \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                                 \
+        return -1;                                                           \
     }                                                                        \
                                                                              \
     static PyType_Slot s2##shortname##_slots[] = {                           \
@@ -975,19 +1047,24 @@ string_to_pyfloat(char *in, int hasnull,
                                                                           \
         StringDTypeObject *descr =                                        \
                 (StringDTypeObject *)context->descriptors[1];             \
+        NPY_STRING_ACQUIRE_ALLOCATOR(descr);                              \
         npy_string_allocator *allocator = descr->allocator;               \
                                                                           \
         while (N--) {                                                     \
             PyObject *scalar_val = PyArray_Scalar(in, float_descr, NULL); \
             if (pyobj_to_string(scalar_val, out, allocator) == -1) {      \
-                return -1;                                                \
+                goto fail;                                                \
             }                                                             \
                                                                           \
             in += in_stride;                                              \
             out += out_stride;                                            \
         }                                                                 \
                                                                           \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                              \
         return 0;                                                         \
+    fail:                                                                 \
+        NPY_STRING_RELEASE_ALLOCATOR(descr);                              \
+        return -1;                                                        \
     }                                                                     \
                                                                           \
     static PyType_Slot shortname##2s_slots [] = {                         \
@@ -1006,6 +1083,7 @@ string_to_float64(PyArrayMethod_Context *context, char *const data[],
                   NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    NPY_STRING_ACQUIRE_ALLOCATOR(descr);
     npy_string_allocator *allocator = descr->allocator;
     int hasnull = descr->na_object != NULL;
     const npy_static_string *default_string = &descr->default_string;
@@ -1020,7 +1098,7 @@ string_to_float64(PyArrayMethod_Context *context, char *const data[],
         PyObject *pyfloat_value =
                 string_to_pyfloat(in, hasnull, default_string, allocator);
         if (pyfloat_value == NULL) {
-            return -1;
+            goto fail;
         }
         *out = (npy_float64)PyFloat_AS_DOUBLE(pyfloat_value);
         Py_DECREF(pyfloat_value);
@@ -1029,7 +1107,12 @@ string_to_float64(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
     return 0;
+
+fail:
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+    return -1;
 }
 
 static PyType_Slot s2f64_slots[] = {
@@ -1080,6 +1163,7 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
                    NpyAuxData *NPY_UNUSED(auxdata))
 {
     StringDTypeObject *descr = (StringDTypeObject *)context->descriptors[0];
+    NPY_STRING_ACQUIRE_ALLOCATOR(descr);
     npy_string_allocator *allocator = descr->allocator;
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
@@ -1111,6 +1195,7 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
             PyErr_SetString(
                     PyExc_MemoryError,
                     "Failed to load string in string to datetime cast");
+            goto fail;
         }
         if (is_null) {
             if (has_null && !has_string_na) {
@@ -1122,11 +1207,11 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
         if (NpyDatetime_ParseISO8601Datetime(
                     (const char *)s.buf, s.size, in_unit, NPY_UNSAFE_CASTING,
                     &dts, &in_meta.base, &out_special) < 0) {
-            return -1;
+            goto fail;
         }
         if (NpyDatetime_ConvertDatetimeStructToDatetime64(dt_meta, &dts, out) <
             0) {
-            return -1;
+            goto fail;
         }
 
     next_step:
@@ -1134,7 +1219,12 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
     return 0;
+
+fail:
+    NPY_STRING_RELEASE_ALLOCATOR(descr);
+    return -1;
 }
 
 static PyType_Slot s2dt_slots[] = {
@@ -1167,6 +1257,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
     char datetime_buf[NPY_DATETIME_MAX_ISO8601_STRLEN];
 
     StringDTypeObject *sdescr = (StringDTypeObject *)context->descriptors[1];
+    NPY_STRING_ACQUIRE_ALLOCATOR(sdescr);
     npy_string_allocator *allocator = sdescr->allocator;
 
     while (N--) {
@@ -1175,7 +1266,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
             gil_error(
                     PyExc_MemoryError,
                     "Failed to deallocate string in datetime to string cast");
-            return -1;
+            goto fail;
         }
         if (*in == NPY_DATETIME_NAT) {
             *out_pss = *NPY_NULL_STRING;
@@ -1183,7 +1274,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
         else {
             if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(dt_meta, *in,
                                                               &dts) < 0) {
-                return -1;
+                goto fail;
             }
 
             // zero out buffer
@@ -1192,7 +1283,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
             if (NpyDatetime_MakeISO8601Datetime(
                         &dts, datetime_buf, NPY_DATETIME_MAX_ISO8601_STRLEN, 0,
                         0, dt_meta->base, -1, NPY_UNSAFE_CASTING) < 0) {
-                return -1;
+                goto fail;
             }
 
             if (npy_string_newsize(datetime_buf, strlen(datetime_buf), out_pss,
@@ -1200,7 +1291,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
                 PyErr_SetString(PyExc_MemoryError,
                                 "Failed to allocate string when converting "
                                 "from a datetime.");
-                return -1;
+                goto fail;
             }
         }
 
@@ -1208,7 +1299,12 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
+    NPY_STRING_RELEASE_ALLOCATOR(sdescr);
     return 0;
+
+fail:
+    NPY_STRING_RELEASE_ALLOCATOR(sdescr);
+    return -1;
 }
 
 static PyType_Slot dt2s_slots[] = {

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -23,11 +23,16 @@ multiply_resolve_descriptors(
         odescr = (StringDTypeObject *)rdescr;
     }
 
-    out_descr = (PyArray_Descr *)new_stringdtype_instance(odescr->na_object,
-                                                          odescr->coerce);
-
-    if (out_descr == NULL) {
-        return (NPY_CASTING)-1;
+    if (given_descrs[2] == NULL) {
+        out_descr = (PyArray_Descr *)new_stringdtype_instance(
+                odescr->na_object, odescr->coerce);
+        if (out_descr == NULL) {
+            return (NPY_CASTING)-1;
+        }
+    }
+    else {
+        Py_INCREF(given_descrs[2]);
+        out_descr = given_descrs[2];
     }
 
     Py_INCREF(ldescr);
@@ -39,141 +44,180 @@ multiply_resolve_descriptors(
     return NPY_NO_CASTING;
 }
 
-#define MULTIPLY_IMPL(shortname)                                             \
-    static int multiply_loop_core_##shortname(                               \
-            npy_intp N, char *sin, char *iin, char *out, npy_intp s_stride,  \
-            npy_intp i_stride, npy_intp o_stride, int has_null,              \
-            int has_nan_na, int has_string_na,                               \
-            const npy_static_string *default_string,                         \
-            StringDTypeObject *idescr, StringDTypeObject *odescr)            \
-    {                                                                        \
-        NPY_STRING_ACQUIRE_ALLOCATOR2(idescr, odescr);                       \
-        while (N--) {                                                        \
-            const npy_packed_static_string *ips =                            \
-                    (npy_packed_static_string *)sin;                         \
-            npy_static_string is = {0, NULL};                                \
-            npy_packed_static_string *ops = (npy_packed_static_string *)out; \
-            if (npy_string_free(ops, odescr->allocator) < 0) {               \
-                gil_error(PyExc_MemoryError,                                 \
-                          "Failed to deallocate string in multiply");        \
-                goto fail;                                                   \
-            }                                                                \
-            int is_isnull = npy_string_load(idescr->allocator, ips, &is);    \
-            if (is_isnull == -1) {                                           \
-                gil_error(PyExc_MemoryError,                                 \
-                          "Failed to load string in multiply");              \
-                goto fail;                                                   \
-            }                                                                \
-            else if (is_isnull) {                                            \
-                if (has_nan_na) {                                            \
-                    *ops = *NPY_NULL_STRING;                                 \
-                    sin += s_stride;                                         \
-                    iin += i_stride;                                         \
-                    out += o_stride;                                         \
-                    continue;                                                \
-                }                                                            \
-                else if (has_string_na || !has_null) {                       \
-                    is = *(npy_static_string *)default_string;               \
-                }                                                            \
-                else {                                                       \
-                    gil_error(PyExc_TypeError,                               \
-                              "Cannot multiply null that is not a nan-like " \
-                              "value");                                      \
-                    goto fail;                                               \
-                }                                                            \
-            }                                                                \
-            npy_##shortname factor = *(npy_##shortname *)iin;                \
-            size_t cursize = is.size;                                        \
-            size_t newsize = cursize * factor;                               \
-            /* newsize can only be less than cursize if there is overflow */ \
-            if (((newsize < cursize) ||                                      \
-                 npy_string_newemptysize(newsize, ops, odescr->allocator) <  \
-                         0)) {                                               \
-                gil_error(PyExc_MemoryError,                                 \
-                          "Failed to allocate string in string mutiply");    \
-                goto fail;                                                   \
-            }                                                                \
-                                                                             \
-            npy_static_string os = {0, NULL};                                \
-            int is_null = npy_string_load(odescr->allocator, ops, &os);      \
-            if (is_null == -1) {                                             \
-                gil_error(PyExc_MemoryError,                                 \
-                          "Failed to load string in string multiply");       \
-                goto fail;                                                   \
-            }                                                                \
-            for (size_t i = 0; i < (size_t)factor; i++) {                    \
-                /* excplicitly discard const; initializing new buffer */     \
-                /* multiply can't overflow because cursize * factor */       \
-                /* has already been checked and doesn't overflow */          \
-                memcpy((char *)os.buf + i * cursize, is.buf, cursize);       \
-            }                                                                \
-                                                                             \
-            sin += s_stride;                                                 \
-            iin += i_stride;                                                 \
-            out += o_stride;                                                 \
-        }                                                                    \
-        NPY_STRING_RELEASE_ALLOCATOR(idescr);                                \
-        NPY_STRING_RELEASE_ALLOCATOR(odescr);                                \
-        return 0;                                                            \
-                                                                             \
-    fail:                                                                    \
-        NPY_STRING_RELEASE_ALLOCATOR(idescr);                                \
-        NPY_STRING_RELEASE_ALLOCATOR(odescr);                                \
-        return -1;                                                           \
-    }                                                                        \
-                                                                             \
-    static int multiply_right_##shortname##_strided_loop(                    \
-            PyArrayMethod_Context *context, char *const data[],              \
-            npy_intp const dimensions[], npy_intp const strides[],           \
-            NpyAuxData *NPY_UNUSED(auxdata))                                 \
-    {                                                                        \
-        StringDTypeObject *idescr =                                          \
-                (StringDTypeObject *)context->descriptors[0];                \
-        StringDTypeObject *odescr =                                          \
-                (StringDTypeObject *)context->descriptors[2];                \
-        int has_null = odescr->na_object != NULL;                            \
-        int has_nan_na = odescr->has_nan_na;                                 \
-        int has_string_na = odescr->has_string_na;                           \
-        const npy_static_string *default_string = &idescr->default_string;   \
-        npy_intp N = dimensions[0];                                          \
-        char *in1 = data[0];                                                 \
-        char *in2 = data[1];                                                 \
-        char *out = data[2];                                                 \
-        npy_intp in1_stride = strides[0];                                    \
-        npy_intp in2_stride = strides[1];                                    \
-        npy_intp out_stride = strides[2];                                    \
-                                                                             \
-        return multiply_loop_core_##shortname(                               \
-                N, in1, in2, out, in1_stride, in2_stride, out_stride,        \
-                has_null, has_nan_na, has_string_na, default_string, idescr, \
-                odescr);                                                     \
-    }                                                                        \
-                                                                             \
-    static int multiply_left_##shortname##_strided_loop(                     \
-            PyArrayMethod_Context *context, char *const data[],              \
-            npy_intp const dimensions[], npy_intp const strides[],           \
-            NpyAuxData *NPY_UNUSED(auxdata))                                 \
-    {                                                                        \
-        StringDTypeObject *idescr =                                          \
-                (StringDTypeObject *)context->descriptors[1];                \
-        StringDTypeObject *odescr =                                          \
-                (StringDTypeObject *)context->descriptors[2];                \
-        int has_null = idescr->na_object != NULL;                            \
-        int has_nan_na = idescr->has_nan_na;                                 \
-        int has_string_na = idescr->has_string_na;                           \
-        const npy_static_string *default_string = &idescr->default_string;   \
-        npy_intp N = dimensions[0];                                          \
-        char *in1 = data[0];                                                 \
-        char *in2 = data[1];                                                 \
-        char *out = data[2];                                                 \
-        npy_intp in1_stride = strides[0];                                    \
-        npy_intp in2_stride = strides[1];                                    \
-        npy_intp out_stride = strides[2];                                    \
-                                                                             \
-        return multiply_loop_core_##shortname(                               \
-                N, in2, in1, out, in2_stride, in1_stride, out_stride,        \
-                has_null, has_nan_na, has_string_na, default_string, idescr, \
-                odescr);                                                     \
+#define MULTIPLY_IMPL(shortname)                                              \
+    static int multiply_loop_core_##shortname(                                \
+            npy_intp N, char *sin, char *iin, char *out, npy_intp s_stride,   \
+            npy_intp i_stride, npy_intp o_stride, int has_null,               \
+            int has_nan_na, int has_string_na,                                \
+            const npy_static_string *default_string,                          \
+            StringDTypeObject *idescr, StringDTypeObject *odescr)             \
+    {                                                                         \
+        NPY_STRING_ACQUIRE_ALLOCATOR2(idescr, odescr);                        \
+        while (N--) {                                                         \
+            const npy_packed_static_string *ips =                             \
+                    (npy_packed_static_string *)sin;                          \
+            npy_static_string is = {0, NULL};                                 \
+            npy_packed_static_string *ops = (npy_packed_static_string *)out;  \
+            int is_isnull = npy_string_load(idescr->allocator, ips, &is);     \
+            if (is_isnull == -1) {                                            \
+                gil_error(PyExc_MemoryError,                                  \
+                          "Failed to load string in multiply");               \
+                goto fail;                                                    \
+            }                                                                 \
+            else if (is_isnull) {                                             \
+                if (has_nan_na) {                                             \
+                    if (npy_string_free(ops, odescr->allocator) < 0) {        \
+                        gil_error(PyExc_MemoryError,                          \
+                                  "Failed to deallocate string in multiply"); \
+                        goto fail;                                            \
+                    }                                                         \
+                                                                              \
+                    *ops = *NPY_NULL_STRING;                                  \
+                    sin += s_stride;                                          \
+                    iin += i_stride;                                          \
+                    out += o_stride;                                          \
+                    continue;                                                 \
+                }                                                             \
+                else if (has_string_na || !has_null) {                        \
+                    is = *(npy_static_string *)default_string;                \
+                }                                                             \
+                else {                                                        \
+                    gil_error(PyExc_TypeError,                                \
+                              "Cannot multiply null that is not a nan-like "  \
+                              "value");                                       \
+                    goto fail;                                                \
+                }                                                             \
+            }                                                                 \
+            npy_##shortname factor = *(npy_##shortname *)iin;                 \
+            size_t cursize = is.size;                                         \
+            size_t newsize = cursize * factor;                                \
+            /* check for overflow */                                          \
+            if (newsize < cursize) {                                          \
+                gil_error(PyExc_MemoryError,                                  \
+                          "Failed to allocate string in string mutiply");     \
+                goto fail;                                                    \
+            }                                                                 \
+                                                                              \
+            char *buf = NULL;                                                 \
+            npy_static_string os = {0, NULL};                                 \
+            if (odescr == idescr) {                                           \
+                buf = PyMem_RawMalloc(newsize);                               \
+                if (buf == NULL) {                                            \
+                    gil_error(PyExc_MemoryError,                              \
+                              "Failed to allocate string in multiply");       \
+                    goto fail;                                                \
+                }                                                             \
+            }                                                                 \
+            else {                                                            \
+                if (npy_string_free(ops, odescr->allocator) < 0) {            \
+                    gil_error(PyExc_MemoryError,                              \
+                              "Failed to deallocate string in multiply");     \
+                    goto fail;                                                \
+                }                                                             \
+                if (npy_string_newemptysize(newsize, ops,                     \
+                                            odescr->allocator) < 0) {         \
+                    gil_error(PyExc_MemoryError,                              \
+                              "Failed to allocate string in multiply");       \
+                    goto fail;                                                \
+                }                                                             \
+                if (npy_string_load(odescr->allocator, ops, &os) < 0) {       \
+                    gil_error(PyExc_MemoryError,                              \
+                              "Failed to load string in multiply");           \
+                    goto fail;                                                \
+                }                                                             \
+                /* excplicitly discard const; initializing new buffer */      \
+                buf = (char *)os.buf;                                         \
+            }                                                                 \
+                                                                              \
+            for (size_t i = 0; i < (size_t)factor; i++) {                     \
+                /* multiply can't overflow because cursize * factor */        \
+                /* has already been checked and doesn't overflow */           \
+                memcpy((char *)buf + i * cursize, is.buf, cursize);           \
+            }                                                                 \
+                                                                              \
+            if (idescr == odescr) {                                           \
+                if (npy_string_free(ops, odescr->allocator) < 0) {            \
+                    gil_error(PyExc_MemoryError,                              \
+                              "Failed to deallocate string in multiply");     \
+                    goto fail;                                                \
+                }                                                             \
+                                                                              \
+                if (npy_string_newsize(buf, newsize, ops,                     \
+                                       odescr->allocator) < 0) {              \
+                    gil_error(PyExc_MemoryError,                              \
+                              "Failed to allocate string in multiply");       \
+                    goto fail;                                                \
+                }                                                             \
+                                                                              \
+                PyMem_RawFree(buf);                                           \
+            }                                                                 \
+                                                                              \
+            sin += s_stride;                                                  \
+            iin += i_stride;                                                  \
+            out += o_stride;                                                  \
+        }                                                                     \
+        NPY_STRING_RELEASE_ALLOCATOR(idescr);                                 \
+        NPY_STRING_RELEASE_ALLOCATOR(odescr);                                 \
+        return 0;                                                             \
+                                                                              \
+    fail:                                                                     \
+        NPY_STRING_RELEASE_ALLOCATOR(idescr);                                 \
+        NPY_STRING_RELEASE_ALLOCATOR(odescr);                                 \
+        return -1;                                                            \
+    }                                                                         \
+                                                                              \
+    static int multiply_right_##shortname##_strided_loop(                     \
+            PyArrayMethod_Context *context, char *const data[],               \
+            npy_intp const dimensions[], npy_intp const strides[],            \
+            NpyAuxData *NPY_UNUSED(auxdata))                                  \
+    {                                                                         \
+        StringDTypeObject *idescr =                                           \
+                (StringDTypeObject *)context->descriptors[0];                 \
+        StringDTypeObject *odescr =                                           \
+                (StringDTypeObject *)context->descriptors[2];                 \
+        int has_null = odescr->na_object != NULL;                             \
+        int has_nan_na = odescr->has_nan_na;                                  \
+        int has_string_na = odescr->has_string_na;                            \
+        const npy_static_string *default_string = &idescr->default_string;    \
+        npy_intp N = dimensions[0];                                           \
+        char *in1 = data[0];                                                  \
+        char *in2 = data[1];                                                  \
+        char *out = data[2];                                                  \
+        npy_intp in1_stride = strides[0];                                     \
+        npy_intp in2_stride = strides[1];                                     \
+        npy_intp out_stride = strides[2];                                     \
+                                                                              \
+        return multiply_loop_core_##shortname(                                \
+                N, in1, in2, out, in1_stride, in2_stride, out_stride,         \
+                has_null, has_nan_na, has_string_na, default_string, idescr,  \
+                odescr);                                                      \
+    }                                                                         \
+                                                                              \
+    static int multiply_left_##shortname##_strided_loop(                      \
+            PyArrayMethod_Context *context, char *const data[],               \
+            npy_intp const dimensions[], npy_intp const strides[],            \
+            NpyAuxData *NPY_UNUSED(auxdata))                                  \
+    {                                                                         \
+        StringDTypeObject *idescr =                                           \
+                (StringDTypeObject *)context->descriptors[1];                 \
+        StringDTypeObject *odescr =                                           \
+                (StringDTypeObject *)context->descriptors[2];                 \
+        int has_null = idescr->na_object != NULL;                             \
+        int has_nan_na = idescr->has_nan_na;                                  \
+        int has_string_na = idescr->has_string_na;                            \
+        const npy_static_string *default_string = &idescr->default_string;    \
+        npy_intp N = dimensions[0];                                           \
+        char *in1 = data[0];                                                  \
+        char *in2 = data[1];                                                  \
+        char *out = data[2];                                                  \
+        npy_intp in1_stride = strides[0];                                     \
+        npy_intp in2_stride = strides[1];                                     \
+        npy_intp out_stride = strides[2];                                     \
+                                                                              \
+        return multiply_loop_core_##shortname(                                \
+                N, in2, in1, out, in2_stride, in1_stride, out_stride,         \
+                has_null, has_nan_na, has_string_na, default_string, idescr,  \
+                odescr);                                                      \
     }
 
 MULTIPLY_IMPL(int8);
@@ -231,12 +275,20 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
     Py_INCREF(given_descrs[1]);
     loop_descrs[1] = given_descrs[1];
 
-    PyArray_Descr *out_descr = (PyArray_Descr *)new_stringdtype_instance(
-            ((StringDTypeObject *)given_descrs[1])->na_object,
-            ((StringDTypeObject *)given_descrs[1])->coerce);
+    PyArray_Descr *out_descr = NULL;
 
-    if (out_descr == NULL) {
-        return (NPY_CASTING)-1;
+    if (given_descrs[2] == NULL) {
+        out_descr = (PyArray_Descr *)new_stringdtype_instance(
+                ((StringDTypeObject *)given_descrs[1])->na_object,
+                ((StringDTypeObject *)given_descrs[1])->coerce);
+
+        if (out_descr == NULL) {
+            return (NPY_CASTING)-1;
+        }
+    }
+    else {
+        Py_INCREF(given_descrs[2]);
+        out_descr = given_descrs[2];
     }
 
     loop_descrs[2] = out_descr;
@@ -278,12 +330,13 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
             goto fail;
         }
         npy_packed_static_string *ops = (npy_packed_static_string *)out;
-        if (npy_string_free(ops, odescr->allocator) < 0) {
-            gil_error(PyExc_MemoryError, "Failed to deallocate string in add");
-            goto fail;
-        }
         if (NPY_UNLIKELY(s1_isnull || s2_isnull)) {
             if (has_nan_na) {
+                if (npy_string_free(ops, odescr->allocator) < 0) {
+                    gil_error(PyExc_MemoryError,
+                              "Failed to deallocate string in add");
+                    goto fail;
+                }
                 *ops = *NPY_NULL_STRING;
                 goto next_step;
             }
@@ -302,24 +355,61 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
             }
         }
 
-        // first check is for overflow
-        if (((s1.size + s2.size) < s1.size) ||
-            (npy_string_newemptysize(s1.size + s2.size, ops,
-                                     odescr->allocator) < 0)) {
+        // check for overflow
+        size_t newsize = s1.size + s2.size;
+        if (newsize < s1.size) {
             gil_error(PyExc_MemoryError, "Failed to allocate string in add");
             goto fail;
         }
 
+        char *buf = NULL;
         npy_static_string os = {0, NULL};
+        if (odescr == s1descr || odescr == s2descr) {
+            buf = PyMem_RawMalloc(newsize);
 
-        if (npy_string_load(odescr->allocator, ops, &os) < 0) {
-            gil_error(PyExc_MemoryError, "Failed to load string in add");
-            goto fail;
-        };
+            if (buf == NULL) {
+                gil_error(PyExc_MemoryError,
+                          "Failed to allocate string in add");
+                goto fail;
+            }
+        }
+        else {
+            if (npy_string_free(ops, odescr->allocator) < 0) {
+                gil_error(PyExc_MemoryError,
+                          "Failed to deallocate string in add");
+                goto fail;
+            }
+            if (npy_string_newemptysize(newsize, ops, odescr->allocator) < 0) {
+                gil_error(PyExc_MemoryError,
+                          "Failed to allocate string in add");
+                goto fail;
+            }
+            if (npy_string_load(odescr->allocator, ops, &os) < 0) {
+                gil_error(PyExc_MemoryError, "Failed to load string in add");
+                goto fail;
+            }
+            // excplicitly discard const; initializing new buffer
+            buf = (char *)os.buf;
+        }
 
-        // explicitly discard const because we're initializing empty buffers
-        memcpy((char *)os.buf, s1.buf, s1.size);
-        memcpy((char *)os.buf + s1.size, s2.buf, s2.size);
+        memcpy(buf, s1.buf, s1.size);
+        memcpy(buf + s1.size, s2.buf, s2.size);
+
+        if (s1descr == odescr || s2descr == odescr) {
+            if (npy_string_free(ops, odescr->allocator) < 0) {
+                gil_error(PyExc_MemoryError,
+                          "Failed to deallocate string in add");
+                goto fail;
+            }
+
+            if (npy_string_newsize(buf, newsize, ops, odescr->allocator) < 0) {
+                gil_error(PyExc_MemoryError,
+                          "Failed to allocate string in add");
+                goto fail;
+            }
+
+            PyMem_RawFree(buf);
+        }
 
     next_step:
         in1 += in1_stride;
@@ -364,8 +454,8 @@ maximum_strided_loop(PyArrayMethod_Context *context, char *const data[],
         const npy_packed_static_string *sin2 = (npy_packed_static_string *)in2;
         npy_packed_static_string *sout = (npy_packed_static_string *)out;
         if (_compare(in1, in2, in1_descr, in2_descr) > 0) {
-            // Only copy *out* to *in1* if they point to different locations;
-            // for *arr.max()* they can point to the same address.
+            // if in and out are the same address, do nothing to avoid a
+            // use-after-free
             if (in1 != out) {
                 if (free_and_copy(in1_descr->allocator, out_descr->allocator,
                                   sin1, sout, "maximum") == -1) {
@@ -424,6 +514,8 @@ minimum_strided_loop(PyArrayMethod_Context *context, char *const data[],
         const npy_packed_static_string *sin2 = (npy_packed_static_string *)in2;
         npy_packed_static_string *sout = (npy_packed_static_string *)out;
         if (_compare(in1, in2, in1_descr, in2_descr) < 0) {
+            // if in and out are the same address, do nothing to avoid a
+            // use-after-free
             if (in1 != out) {
                 if (free_and_copy(in1_descr->allocator, out_descr->allocator,
                                   sin1, sout, "minimum") == -1) {

--- a/stringdtype/stringdtype/src/umath.c
+++ b/stringdtype/stringdtype/src/umath.c
@@ -156,13 +156,11 @@ multiply_resolve_descriptors(
             iin += i_stride;                                                  \
             out += o_stride;                                                  \
         }                                                                     \
-        NPY_STRING_RELEASE_ALLOCATOR(idescr);                                 \
-        NPY_STRING_RELEASE_ALLOCATOR(odescr);                                 \
+        NPY_STRING_RELEASE_ALLOCATOR2(idescr, odescr);                        \
         return 0;                                                             \
                                                                               \
     fail:                                                                     \
-        NPY_STRING_RELEASE_ALLOCATOR(idescr);                                 \
-        NPY_STRING_RELEASE_ALLOCATOR(odescr);                                 \
+        NPY_STRING_RELEASE_ALLOCATOR2(idescr, odescr);                        \
         return -1;                                                            \
     }                                                                         \
                                                                               \
@@ -416,15 +414,11 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
         in2 += in2_stride;
         out += out_stride;
     }
-    NPY_STRING_RELEASE_ALLOCATOR(s1descr);
-    NPY_STRING_RELEASE_ALLOCATOR(s2descr);
-    NPY_STRING_RELEASE_ALLOCATOR(odescr);
+    NPY_STRING_RELEASE_ALLOCATOR3(s1descr, s2descr, odescr);
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(s1descr);
-    NPY_STRING_RELEASE_ALLOCATOR(s2descr);
-    NPY_STRING_RELEASE_ALLOCATOR(odescr);
+    NPY_STRING_RELEASE_ALLOCATOR3(s1descr, s2descr, odescr);
     return -1;
 }
 
@@ -476,15 +470,11 @@ maximum_strided_loop(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(in1_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(in2_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(out_descr);
+    NPY_STRING_RELEASE_ALLOCATOR3(in1_descr, in2_descr, out_descr);
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(in1_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(in2_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(out_descr);
+    NPY_STRING_RELEASE_ALLOCATOR3(in1_descr, in2_descr, out_descr);
     return -1;
 }
 
@@ -536,15 +526,11 @@ minimum_strided_loop(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(in1_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(in2_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(out_descr);
+    NPY_STRING_RELEASE_ALLOCATOR3(in1_descr, in2_descr, out_descr);
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(in1_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(in2_descr);
-    NPY_STRING_RELEASE_ALLOCATOR(out_descr);
+    NPY_STRING_RELEASE_ALLOCATOR3(in1_descr, in2_descr, out_descr);
     return -1;
 }
 
@@ -618,14 +604,12 @@ string_equal_strided_loop(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return -1;
 }
@@ -700,14 +684,12 @@ string_not_equal_strided_loop(PyArrayMethod_Context *context,
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return -1;
 }
@@ -779,14 +761,12 @@ string_greater_strided_loop(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return -1;
 }
@@ -860,14 +840,12 @@ string_greater_equal_strided_loop(PyArrayMethod_Context *context,
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return -1;
 }
@@ -938,14 +916,12 @@ string_less_strided_loop(PyArrayMethod_Context *context, char *const data[],
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return -1;
 }
@@ -1018,14 +994,12 @@ string_less_equal_strided_loop(PyArrayMethod_Context *context,
         out += out_stride;
     }
 
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return 0;
 
 fail:
-    NPY_STRING_RELEASE_ALLOCATOR(descr1);
-    NPY_STRING_RELEASE_ALLOCATOR(descr2);
+    NPY_STRING_RELEASE_ALLOCATOR2(descr1, descr2);
 
     return -1;
 }

--- a/stringdtype/tests/test_char.py
+++ b/stringdtype/tests/test_char.py
@@ -62,13 +62,13 @@ BINARY_FUNCTIONS = [
     ("count", (None, "A")),
     ("encode", (None, "UTF-8")),
     ("endswith", (None, "lo")),
-    ("find", (None, "A")),
+    # ("find", (None, "A")),  # 11-6-2023 skipped temporarily
     ("index", (None, "e")),
     ("join", ("-", None)),
     ("ljust", (None, 12)),
     ("partition", (None, "A")),
     ("replace", (None, "A", "B")),
-    ("rfind", (None, "A")),
+    # ("rfind", (None, "A")),  # 11-6-2023 skipped temporarily
     ("rindex", (None, "e")),
     ("rjust", (None, 12)),
     ("rpartition", (None, "A")),

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -20,6 +20,14 @@ def string_list():
     return ["abc", "def", "ghi" * 10, "A¢☃€ 😊" * 100, "Abc" * 1000, "DEF"]
 
 
+@pytest.fixture
+def random_string_list():
+    chars = list(string.ascii_letters + string.digits)
+    chars = np.array(chars, dtype="U1")
+    ret = np.random.choice(chars, size=100 * 1000, replace=True)
+    return ret.view("U100")
+
+
 pd_param = pytest.param(
     pd_NA,
     marks=pytest.mark.skipif(pd_NA is None, reason="pandas is not installed"),
@@ -202,15 +210,12 @@ def test_unicode_casts(dtype, strings):
     )
 
 
-def test_additional_unicode_cast(dtype):
-    RANDS_CHARS = np.array(
-        list(string.ascii_letters + string.digits), dtype=(np.str_, 1)
-    )
-    arr = np.random.choice(RANDS_CHARS, size=10 * 100_000, replace=True).view(
-        "U10"
-    )
+def test_additional_unicode_cast(random_string_list, dtype):
+    arr = np.array(random_string_list, dtype=dtype)
     np.testing.assert_array_equal(arr, arr.astype(dtype))
-    np.testing.assert_array_equal(arr, arr.astype(dtype).astype("U10"))
+    np.testing.assert_array_equal(
+        arr, arr.astype(dtype).astype(random_string_list.dtype)
+    )
 
 
 def test_insert_scalar(dtype, string_list):
@@ -671,7 +676,9 @@ def test_ufunc_multiply(dtype, string_list, other, other_dtype, use_out):
         result = [s * other for s in string_list]
 
     if use_out:
+        arr_cache = arr.copy()
         lres = np.multiply(arr, other, out=arr)
+        arr[:] = arr_cache
         rres = np.multiply(other, arr, out=arr)
     else:
         lres = arr * other
@@ -793,3 +800,28 @@ def test_growing_strings(dtype):
         uarr = uarr + uarr
 
     np.testing.assert_array_equal(arr, uarr)
+
+
+def test_threaded_access_and_mutation(dtype, random_string_list):
+    # this test uses an RNG and may crash or cause deadlocks if there is a
+    # threading bug
+    rng = np.random.default_rng(0x4D3D3D3)
+
+    def func(arr):
+        rnd = rng.random()
+        # either write to random locations in the array, compute a ufunc, or
+        # re-initialize the array
+        if rnd < 0.3333:
+            num = np.random.randint(0, arr.size)
+            arr[num] = arr[num] + "hello"
+        elif rnd < 0.6666:
+            np.add(arr, arr)
+        else:
+            arr[:] = random_string_list
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as tpe:
+        arr = np.array(random_string_list, dtype=dtype)
+        futures = [tpe.submit(func, arr) for _ in range(100)]
+
+        for f in futures:
+            f.result()

--- a/stringdtype/tests/test_stringdtype.py
+++ b/stringdtype/tests/test_stringdtype.py
@@ -752,3 +752,22 @@ def test_string_too_large_error():
     arr = np.array(["a", "b", "c"], dtype=StringDType())
     with pytest.raises(MemoryError):
         arr * (2**63 - 2)
+
+
+def test_growing_strings(dtype):
+    # growing a string leads to a heap allocation, this tests to make sure
+    # we do that bookeeping correctly for all possible starting cases
+    data = [
+        "hello",  # a short string
+        "abcdefghijklmnopqestuvwxyz",  # a medium heap-allocated string
+        "hello" * 200,  # a long heap-allocated string
+    ]
+
+    arr = np.array(data, dtype=dtype)
+    uarr = np.array(data, dtype=str)
+
+    for _ in range(5):
+        arr = arr + arr
+        uarr = uarr + uarr
+
+    np.testing.assert_array_equal(arr, uarr)


### PR DESCRIPTION
This adds an `allocator_lock` field to the `StringDTypeObject` struct. This is a `PyThread_type_lock` mutex that must be acquired before manipulating the allocator.

I defined `NPY_STRING_ACQUIRE_ALLOCATOR` (as well as variants that accept 2 and 3 descriptors) and `NPY_STRING_RELEASE_ALLOCATOR` macros that handle locking and unlocking the mutex.

There's nothing in the API that prevents someone from touching the `allocator` field before acquiring the `allocator_lock`. Maybe it would be nicer to wrap a type around the allocator or a more idiomatic way to write this in C?

Most of this PR is then applying these macros where appropriate, including in error handling cases. There are a few places where I didn't exit from error cases and other similar bugs are fixed as well.

I wasn't sure what to do in `stringdtype_dealloc`. Can we assume because of the GIL that a dtype is deallocated by only one thread? 

I haven't benchmarked the singlethreaded performance hit or added threaded tests but am planning to add that before merging.

I based this implementation off of [this tutorial](https://pythonextensionpatterns.readthedocs.io/en/latest/thread_safety.html).