### PR TITLE
ENH: Add usage of new sorting dtype slots

### DIFF
--- a/mpfdtype/mpfdtype/src/dtype.c
+++ b/mpfdtype/mpfdtype/src/dtype.c
@@ -159,6 +159,27 @@ mpf_getitem(MPFDTypeObject *descr, char *dataptr)
     return (PyObject *)new;
 }
 
+
+int mpf_compare(char *in1_ptr, char *in2_ptr, PyArray_Descr *descr)
+{
+    /* Note that it is probably better to only get the descr from `ap` */
+    mpfr_prec_t precision = ((MPFDTypeObject *)descr)->precision;
+
+    mpfr_ptr in1, in2;
+
+    mpf_load(in1, in1_ptr, precision);
+    mpf_load(in2, in2_ptr, precision);
+
+    if (!mpfr_total_order_p(in1, in2)) {
+        return 1;
+    }
+    if (!mpfr_total_order_p(in2, in1)) {
+        return -1;
+    }
+    return 0;
+}
+
+
 static PyType_Slot MPFDType_Slots[] = {
         {NPY_DT_ensure_canonical, &ensure_canonical},
         {NPY_DT_common_instance, &common_instance},
@@ -166,6 +187,7 @@ static PyType_Slot MPFDType_Slots[] = {
         {NPY_DT_discover_descr_from_pyobject, &mpf_discover_descriptor_from_pyobject},
         {NPY_DT_setitem, &mpf_setitem},
         {NPY_DT_getitem, &mpf_getitem},
+        {NPY_DT_sort_compare, &mpf_compare},
         {0, NULL}};
 
 /*

--- a/mpfdtype/mpfdtype/src/terrible_hacks.c
+++ b/mpfdtype/mpfdtype/src/terrible_hacks.c
@@ -35,27 +35,6 @@ copyswap_mpf(char *dst, char *src, int swap, PyArrayObject *ap)
 }
 
 
-/* Should only be used for sorting, so more complex than necessary, probably */
-int compare_mpf(char *in1_ptr, char *in2_ptr, int swap, PyArrayObject *ap)
-{
-    /* Note that it is probably better to only get the descr from `ap` */
-    mpfr_prec_t precision = ((MPFDTypeObject *)PyArray_DESCR(ap))->precision;
-
-    mpfr_ptr in1, in2;
-
-    mpf_load(in1, in1_ptr, precision);
-    mpf_load(in2, in2_ptr, precision);
-
-    if (!mpfr_total_order_p(in1, in2)) {
-        return 1;
-    }
-    if (!mpfr_total_order_p(in2, in1)) {
-        return -1;
-    }
-    return 0;
-}
-
-
 int
 init_terrible_hacks(void) {
     /* Defaults to -1 byt ISNUMBER misfires for it, so use MAX */
@@ -70,7 +49,6 @@ init_terrible_hacks(void) {
     }
     /* ->f slots are the same for all instances (currently). */
     PyDataType_GetArrFuncs(&descr->base)->copyswap = (PyArray_CopySwapFunc *)&copyswap_mpf;
-    PyDataType_GetArrFuncs(&descr->base)->compare = (PyArray_CompareFunc *)&compare_mpf;
     Py_DECREF(descr);
 
     return 0;


### PR DESCRIPTION
**Note**: this PR depends on https://github.com/numpy/numpy/pull/28516 and will break without it.

This is to start writing some examples for the new sorting slots in https://github.com/numpy/numpy/pull/28516. Currently, just a patch to use the new `sort_compare` slot for mpfdtype: this is the only place I found sorting-related features to be implemented already but there's probably ways we can optimize it further for the various dtypes.