### PR TITLE
NaN tests + Workflow + README fixes

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -194,8 +194,8 @@ jobs:
           path: ./quaddtype/wheelhouse/*.whl
           name: wheels-windows-${{ matrix.architecture }}
 
-  publish_to_testpypi:
-    name: Publish to TestPyPI
+  publish_to_pypi:
+    name: Publish to PyPI
     needs: [build_wheels_linux, build_wheels_macos, build_wheels_windows]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/quaddtype-v')
@@ -204,12 +204,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
-      - name: Publish to TestPyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.9.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
           packages-dir: dist/*
 
   create_release:

--- a/quaddtype/README.md
+++ b/quaddtype/README.md
@@ -1,10 +1,12 @@
 # Numpy-QuadDType
 
+A cross-platform Quad (128-bit) float Data-Type for NumPy.
+
 ## Installation
 
-```
-pip install numpy==2.1.0
-pip install -i https://test.pypi.org/simple/ quaddtype
+```bash
+pip install numpy
+pip install numpy-quaddtype
 ```
 
 ## Usage
@@ -21,7 +23,7 @@ np.array([1,2,3], dtype=QuadPrecDType("sleef"))
 np.array([1,2,3], dtype=QuadPrecDType("longdouble"))
 ```
 
-## Install from source
+## Installation from source
 
 The code needs the quad precision pieces of the sleef library, which
 is not available on most systems by default, so we have to generate
@@ -29,30 +31,24 @@ that first.  The below assumes one has the required pieces to build
 sleef (cmake and libmpfr-dev), and that one is in the package
 directory locally.
 
-```
-git clone https://github.com/shibatch/sleef.git
+```bash
+git clone --branch 3.8 https://github.com/shibatch/sleef.git
 cd sleef
 cmake -S . -B build -DSLEEF_BUILD_QUAD:BOOL=ON -DSLEEF_BUILD_SHARED_LIBS:BOOL=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 cmake --build build/ --clean-first -j
 cd ..
 ```
 
-In principle, one can now install this system-wide, but easier would
-seem to use the version that was just created, as follows:
-```
+Building the `numpy-quaddtype` package from locally installed sleef:
+```bash
 export SLEEF_DIR=$PWD/sleef/build
 export LIBRARY_PATH=$SLEEF_DIR/lib
 export C_INCLUDE_PATH=$SLEEF_DIR/include
 export CPLUS_INCLUDE_PATH=$SLEEF_DIR/include
-python3 -m venv temp
-source temp/bin/activate
+
+# Install the package
 pip install meson-python numpy pytest
 pip install -e . -v --no-build-isolation
 export LD_LIBRARY_PATH=$SLEEF_DIR/lib
 ```
 
-Here, we created an editable install on purpose, so one can just work
-from the package directory if needed, e.g., to run the tests with,
-```
-python -m pytest
-```

--- a/quaddtype/tests/test_quaddtype.py
+++ b/quaddtype/tests/test_quaddtype.py
@@ -70,6 +70,10 @@ def test_unary_ops(op, val, expected):
 
     assert result == expected_val, f"{op}({val}) should be {expected}, but got {result}"
 
+def test_inf():
+    assert QuadPrecision("inf") > QuadPrecision("1e1000")
+    assert QuadPrecision("-inf") < QuadPrecision("-1e1000")
+
 
 def test_dtype_creation():
     dtype = QuadPrecDType()


### PR DESCRIPTION
This PR contributes as follows:
- Sleef comparison operators with NaN return false on equal and not equal comparisons (unlike the proposition [NaN-wikipedia](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN) I earlier found in IEEE-754 that says `nan != nan` should return true) hence removing that particular test
- Updated the README file with latest instructions to follow for installation
- Modifies workflow to publish on PyPI rather than Test-PyPI  