### PR TITLE
`np.finfo` support for quaddtyoe

### DIFF
--- a/quaddtype/numpy_quaddtype/__init__.py
+++ b/quaddtype/numpy_quaddtype/__init__.py
@@ -8,6 +8,8 @@ from ._quaddtype_main import (
     get_quadblas_version
 )
 
+from dataclasses import dataclass
+
 __all__ = [
     'QuadPrecision', 'QuadPrecDType', 'SleefQuadPrecision', 'LongDoubleQuadPrecision',
     'SleefQuadPrecDType', 'LongDoubleQuadPrecDType', 'is_longdouble_128', 
@@ -15,7 +17,9 @@ __all__ = [
     'pi', 'e', 'log2e', 'log10e', 'ln2', 'ln10', 'max_value', 'epsilon',
     'smallest_normal', 'smallest_subnormal', 'bits', 'precision', 'resolution',
     # QuadBLAS related functions
-    'set_num_threads', 'get_num_threads', 'get_quadblas_version'
+    'set_num_threads', 'get_num_threads', 'get_quadblas_version',
+    # finfo class
+    'QuadPrecFinfo'
 ]
 
 def SleefQuadPrecision(value):
@@ -43,3 +47,39 @@ smallest_subnormal = get_sleef_constant("smallest_subnormal")
 bits = get_sleef_constant("bits")
 precision = get_sleef_constant("precision")
 resolution = get_sleef_constant("resolution")
+
+@dataclass
+class QuadPrecFinfo:
+    """Floating-point information for quadruple precision dtype.
+    
+    This class provides information about the floating-point representation
+    used by the QuadPrecDType, similar to numpy.finfo but customized for
+    quad precision arithmetic.
+    """
+    bits: int = int(bits)
+    eps: float = float(epsilon)
+    epsneg: float = float(epsilon)
+    iexp: int = int(precision)
+    machar: object = None
+    machep: float = float(epsilon)
+    max: float = float(max_value)
+    maxexp: float = float(max_value)
+    min: float = float(smallest_normal)
+    minexp: float = float(smallest_normal)
+    negep: float = float(epsilon)
+    nexp: int = int(bits) - int(precision) - 1
+    nmant: int = int(precision)
+    precision: int = int(precision)
+    resolution: float = float(resolution)
+    tiny: float = float(smallest_normal)
+    smallest_normal: float = float(smallest_normal)
+    smallest_subnormal: float = float(smallest_subnormal)
+
+    def get(self, attr):
+        return getattr(self, attr, None)
+    
+    def __str__(self):
+        return f"QuadPrecFinfo(precision={self.precision}, resolution={self.resolution})"
+    
+    def __repr__(self):
+        return f"QuadPrecFinfo(max={self.max}, min={self.min}, eps={self.eps}, bits={self.bits})"

--- a/quaddtype/numpy_quaddtype/src/dtype.c
+++ b/quaddtype/numpy_quaddtype/src/dtype.c
@@ -176,6 +176,28 @@ quadprec_default_descr(PyArray_DTypeMeta *cls)
     return (PyArray_Descr *)temp;
 }
 
+static PyObject *
+quad_finfo(PyArray_Descr *descr)
+{
+    
+    PyObject *finfo_dict = PyDict_New();
+    if (!finfo_dict) return NULL;
+    
+    PyDict_SetItemString(finfo_dict, "precision", PyLong_FromLong(34));
+    PyDict_SetItemString(finfo_dict, "bits", PyLong_FromLong(128));
+    
+    PyDict_SetItemString(finfo_dict, "eps", PyLong_FromLong(34));
+
+    PyDict_SetItemString(finfo_dict, "max", PyLong_FromLong(34));
+
+    PyDict_SetItemString(finfo_dict, "tiny", PyLong_FromLong(34));
+
+    PyDict_SetItemString(finfo_dict, "epsneg", PyLong_FromLong(34));
+    PyDict_SetItemString(finfo_dict, "resolution", PyLong_FromLong(34));
+
+    return finfo_dict; 
+}
+
 static PyType_Slot QuadPrecDType_Slots[] = {
         {NPY_DT_ensure_canonical, &ensure_canonical},
         {NPY_DT_common_instance, &common_instance},
@@ -185,6 +207,7 @@ static PyType_Slot QuadPrecDType_Slots[] = {
         {NPY_DT_getitem, &quadprec_getitem},
         {NPY_DT_default_descr, &quadprec_default_descr},
         {NPY_DT_PyArray_ArrFuncs_dotfunc, NULL},
+        {NPY_DT_get_finfo, &quad_finfo},
         {0, NULL}};
 
 static PyObject *

--- a/quaddtype/numpy_quaddtype/src/dtype.c
+++ b/quaddtype/numpy_quaddtype/src/dtype.c
@@ -177,25 +177,35 @@ quadprec_default_descr(PyArray_DTypeMeta *cls)
 }
 
 static PyObject *
-quad_finfo(PyArray_Descr *descr)
+quad_finfo(PyArray_Descr *descr, NPY_DTYPE_INFO_TYPE info_type)
 {
     
-    PyObject *finfo_dict = PyDict_New();
-    if (!finfo_dict) return NULL;
-    
-    PyDict_SetItemString(finfo_dict, "precision", PyLong_FromLong(34));
-    PyDict_SetItemString(finfo_dict, "bits", PyLong_FromLong(128));
-    
-    PyDict_SetItemString(finfo_dict, "eps", PyLong_FromLong(34));
-
-    PyDict_SetItemString(finfo_dict, "max", PyLong_FromLong(34));
-
-    PyDict_SetItemString(finfo_dict, "tiny", PyLong_FromLong(34));
-
-    PyDict_SetItemString(finfo_dict, "epsneg", PyLong_FromLong(34));
-    PyDict_SetItemString(finfo_dict, "resolution", PyLong_FromLong(34));
-
-    return finfo_dict; 
+    // Handle the different info types
+   switch (info_type) {
+       case NPY_DTYPE_INFO_FLOAT:
+           {
+               PyObject *finfo_dict = PyDict_New();
+               if (!finfo_dict) return NULL;
+               
+               PyDict_SetItemString(finfo_dict, "precision", PyLong_FromLong(34));
+               PyDict_SetItemString(finfo_dict, "bits", PyLong_FromLong(128));
+               //  more fields
+               return finfo_dict;
+           }
+       case NPY_DTYPE_INFO_INTEGER:
+           // Not implemented yet, could add iinfo support later
+           PyErr_SetString(PyExc_NotImplementedError, 
+                          "Integer info not implemented for this dtype");
+           return NULL;
+       case NPY_DTYPE_INFO_GENERIC:
+           // Not implemented yet, could add generic info later
+           PyErr_SetString(PyExc_NotImplementedError, 
+                          "Generic info not implemented for this dtype");
+           return NULL;
+       default:
+           PyErr_SetString(PyExc_ValueError, "Unknown dtype info type");
+           return NULL;
+   }
 }
 
 static PyType_Slot QuadPrecDType_Slots[] = {
@@ -207,7 +217,7 @@ static PyType_Slot QuadPrecDType_Slots[] = {
         {NPY_DT_getitem, &quadprec_getitem},
         {NPY_DT_default_descr, &quadprec_default_descr},
         {NPY_DT_PyArray_ArrFuncs_dotfunc, NULL},
-        {NPY_DT_get_finfo, &quad_finfo},
+        {NPY_DT_get_dtype_info, &quad_finfo},
         {0, NULL}};
 
 static PyObject *

--- a/quaddtype/numpy_quaddtype/src/scalar.c
+++ b/quaddtype/numpy_quaddtype/src/scalar.c
@@ -239,7 +239,7 @@ QuadPrecision_dealloc(QuadPrecisionObject *self)
 }
 
 PyTypeObject QuadPrecision_Type = {
-        PyVarObject_HEAD_INIT(NULL, 0).tp_name = "numpy_quaddtype.QuadPrecision",
+        PyVarObject_HEAD_INIT(NULL, 0).tp_name = "numpy_quaddtype.QuadPrecDType",
         .tp_basicsize = sizeof(QuadPrecisionObject),
         .tp_itemsize = 0,
         .tp_new = QuadPrecision_new,
@@ -253,5 +253,6 @@ PyTypeObject QuadPrecision_Type = {
 int
 init_quadprecision_scalar(void)
 {
+    QuadPrecision_Type.tp_base = &PyFloatingArrType_Type;
     return PyType_Ready(&QuadPrecision_Type);
 }

--- a/quaddtype/reinstall.sh
+++ b/quaddtype/reinstall.sh
@@ -8,7 +8,7 @@ if [ -d "build/" ]; then
     rm -rf subprojects/sleef
 fi
 
-export CFLAGS="-g -O0" 
-export CXXFLAGS="-g -O0"
+# export CFLAGS="-g -O0" 
+# export CXXFLAGS="-g -O0"
 python -m pip uninstall -y numpy_quaddtype
-python -m pip install . -v
+python -m pip install . --no-build-isolation -v 2>&1 | tee build_log.txt


### PR DESCRIPTION
Making this PR here as well, as a demonstration to how `np.finfo` and other related information can be passed to NumPy.
This maybe done from the Python side as well i.e. inside `__init__.py` something like
```python
QuadPrecDType.finfo = lambda: QuadPrecFinfo()
```
But this just feels so illegal that's why registering as `.tp_methods`

From the NumPy side it requires https://github.com/numpy/numpy/pull/29771 to get merged.