### PR TITLE
BUG: No implicit setting of openmp threads

### DIFF
--- a/quaddtype/meson.build
+++ b/quaddtype/meson.build
@@ -37,7 +37,7 @@ npymath_lib = c.find_library('npymath', dirs: npymath_path)
 dependencies = [py_dep, qblas_dep, sleef_dep, sleefquad_dep, npymath_lib]
 
 # Add OpenMP dependency (optional, for threading)
-openmp_dep = dependency('openmp', required: false)
+openmp_dep = dependency('openmp', required: false, static: false)
 if openmp_dep.found()
     dependencies += openmp_dep
 endif

--- a/quaddtype/numpy_quaddtype/src/umath/matmul.cpp
+++ b/quaddtype/numpy_quaddtype/src/umath/matmul.cpp
@@ -396,9 +396,6 @@ init_matmul_ops(PyObject *numpy)
     PyArray_DTypeMeta *dtypes[3] = {&QuadPrecDType, &QuadPrecDType, &QuadPrecDType};
 
 #ifndef DISABLE_QUADBLAS
-    // set threading to max
-    int num_threads = _quadblas_get_num_threads();
-    _quadblas_set_num_threads(num_threads);
 
     PyType_Slot slots[] = {
             {NPY_METH_resolve_descriptors, (void *)&quad_matmul_resolve_descriptors},


### PR DESCRIPTION
Can Close numpy/numpy-quaddtype#22 

- Removes implicit setting of threads for matmul ops