### PR TITLE
FEAT: `fmod` ufunc implementation

### DIFF
--- a/quaddtype/numpy_quaddtype/src/umath/binary_ops.cpp
+++ b/quaddtype/numpy_quaddtype/src/umath/binary_ops.cpp
@@ -232,6 +232,9 @@ init_quad_binary_ops(PyObject *numpy)
     if (create_quad_binary_ufunc<quad_mod, ld_mod>(numpy, "mod") < 0) {
         return -1;
     }
+    if (create_quad_binary_ufunc<quad_fmod, ld_fmod>(numpy, "fmod") < 0) {
+        return -1;
+    }
     if (create_quad_binary_ufunc<quad_minimum, ld_minimum>(numpy, "minimum") < 0) {
         return -1;
     }

--- a/quaddtype/release_tracker.md
+++ b/quaddtype/release_tracker.md
@@ -20,7 +20,7 @@
 | float_power   | ✅    | ✅                                                                   |
 | remainder     | ✅    | ✅                                                                   |
 | mod           | ✅    | ✅                                                                   |
-| fmod          |       |                                                                      |
+| fmod          | ✅    | ✅                                                                   |
 | divmod        |       |                                                                      |
 | absolute      | ✅    | ✅                                                                   |
 | fabs          |       |                                                                      |


### PR DESCRIPTION
## Copilot Summary
This pull request adds support for the `fmod` (floating-point modulo) operation for quad-precision and long double types in the numpy quad dtype extension. It implements the correct mathematical behavior for `fmod`, including handling of edge cases, exposes the new ufunc to Python, documents the feature, and thoroughly tests it with a wide range of inputs and special properties.

**Implementation of fmod operation:**

* Added `quad_fmod` and `ld_fmod` functions in `ops.hpp` to implement floating-point modulo for quad-precision and long double types, with correct handling of NaN, infinity, division by zero, sign preservation, and mathematical properties. [[1]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R556-R595) [[2]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R837-R873)

**Integration and exposure in Python:**

* Registered the new `fmod` ufunc in `init_quad_binary_ops` so it is available as `np.fmod` for quad dtypes.

**Documentation:**

* Updated `release_tracker.md` to mark `fmod` as implemented and tested for both quad and long double types.

**Testing:**

* Added comprehensive tests for `fmod` in `test_quaddtype.py`, covering a wide range of edge cases (NaN, infinities, zeros, sign preservation, and mathematical identities), as well as differences from `mod`/`remainder`.