### PR TITLE
FEAT: `heaviside` ufunc implementation

### DIFF
--- a/quaddtype/numpy_quaddtype/src/ops.hpp
+++ b/quaddtype/numpy_quaddtype/src/ops.hpp
@@ -752,6 +752,26 @@ quad_logaddexp2(const Sleef_quad *x, const Sleef_quad *y)
     return Sleef_addq1_u05(max_val, log2_term);
 }
 
+static inline Sleef_quad
+quad_heaviside(const Sleef_quad *x1, const Sleef_quad *x2)
+{
+    // heaviside(x1, x2) = 0 if x1 < 0, x2 if x1 == 0, 1 if x1 > 0
+    // NaN propagation: only propagate NaN from x1, not from x2 (unless x1 == 0)
+    if (Sleef_iunordq1(*x1, *x1)) {
+        return *x1;  // x1 is NaN, return NaN
+    }
+    
+    if (Sleef_icmpltq1(*x1, QUAD_ZERO)) {
+        return QUAD_ZERO;
+    }
+    else if (Sleef_icmpeqq1(*x1, QUAD_ZERO)) {
+        return *x2;  // When x1 == 0, return x2 (even if x2 is NaN)
+    }
+    else {
+        return QUAD_ONE;
+    }
+}
+
 // Binary long double operations
 typedef long double (*binary_op_longdouble_def)(const long double *, const long double *);
 // Binary long double operations with 2 outputs (for divmod, modf, frexp)
@@ -1000,6 +1020,26 @@ ld_logaddexp2(const long double *x, const long double *y)
     long double max_val = (*x > *y) ? *x : *y;
     // Use native log2l function for base-2 logarithm
     return max_val + log2l(1.0L + exp2l(-abs_diff));
+}
+
+static inline long double
+ld_heaviside(const long double *x1, const long double *x2)
+{
+    // heaviside(x1, x2) = 0 if x1 < 0, x2 if x1 == 0, 1 if x1 > 0
+    // NaN propagation: only propagate NaN from x1, not from x2 (unless x1 == 0)
+    if (isnan(*x1)) {
+        return *x1;  // x1 is NaN, return NaN
+    }
+    
+    if (*x1 < 0.0L) {
+        return 0.0L;
+    }
+    else if (*x1 == 0.0L) {
+        return *x2;  // When x1 == 0, return x2 (even if x2 is NaN)
+    }
+    else {
+        return 1.0L;
+    }
 }
 
 // comparison quad functions

--- a/quaddtype/numpy_quaddtype/src/umath/binary_ops.cpp
+++ b/quaddtype/numpy_quaddtype/src/umath/binary_ops.cpp
@@ -454,6 +454,9 @@ init_quad_binary_ops(PyObject *numpy)
     if (create_quad_binary_ufunc<quad_logaddexp2, ld_logaddexp2>(numpy, "logaddexp2") < 0) {
         return -1;
     }
+    if (create_quad_binary_ufunc<quad_heaviside, ld_heaviside>(numpy, "heaviside") < 0) {
+        return -1;
+    }
     if (create_quad_binary_2out_ufunc<quad_divmod, ld_divmod>(numpy, "divmod") < 0) {
         return -1;
     }

--- a/quaddtype/release_tracker.md
+++ b/quaddtype/release_tracker.md
@@ -26,7 +26,7 @@
 | fabs          | ✅    | ✅                                                                   |
 | rint          | ✅    | ✅                                                                   |
 | sign          | ✅    | ✅                                                                   |
-| heaviside     |       |                                                                      |
+| heaviside     | ✅    | ✅                                                                   |
 | conj          |       |                                                                      |
 | conjugate     |       |                                                                      |
 | exp           | ✅    | ✅                                                                   |


### PR DESCRIPTION
## Copilot Summary
This pull request adds support for the `heaviside` function to the QuadPrecision dtype, implementing both the core logic and comprehensive tests. The implementation follows NumPy's behavior, including correct handling of NaN propagation and broadcasting. Documentation and release tracking have also been updated to reflect this new feature.

**Implementation of `heaviside` function:**

- Added `quad_heaviside` and `ld_heaviside` functions implementing the Heaviside step logic for quad and long double types, with correct NaN propagation and handling for all edge cases. [[1]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R755-R774) [[2]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R1025-R1044)
- Registered the new `heaviside` ufunc for QuadPrecision by updating the binary ops initialization.

**Testing:**

- Added extensive parameterized tests for `np.heaviside` with QuadPrecision, covering basic, edge, special, and broadcasting cases to ensure correctness and compatibility with NumPy's semantics.

**Documentation and tracking:**

- Updated the release tracker documentation to mark `heaviside` as implemented and tested for QuadPrecision.