### PR TITLE
FEAT: `expm1` ufunc implementation

### DIFF
--- a/quaddtype/numpy_quaddtype/src/ops.hpp
+++ b/quaddtype/numpy_quaddtype/src/ops.hpp
@@ -125,6 +125,12 @@ quad_exp2(const Sleef_quad *op)
 }
 
 static inline Sleef_quad
+quad_expm1(const Sleef_quad *op)
+{
+    return Sleef_expm1q1_u10(*op);
+}
+
+static inline Sleef_quad
 quad_sin(const Sleef_quad *op)
 {
     return Sleef_sinq1_u10(*op);
@@ -306,6 +312,12 @@ static inline long double
 ld_exp2(const long double *op)
 {
     return exp2l(*op);
+}
+
+static inline long double
+ld_expm1(const long double *op)
+{
+    return expm1l(*op);
 }
 
 static inline long double

--- a/quaddtype/numpy_quaddtype/src/umath/unary_ops.cpp
+++ b/quaddtype/numpy_quaddtype/src/umath/unary_ops.cpp
@@ -203,6 +203,9 @@ init_quad_unary_ops(PyObject *numpy)
     if (create_quad_unary_ufunc<quad_exp2, ld_exp2>(numpy, "exp2") < 0) {
         return -1;
     }
+    if (create_quad_unary_ufunc<quad_expm1, ld_expm1>(numpy, "expm1") < 0) {
+        return -1;
+    }
     if (create_quad_unary_ufunc<quad_sin, ld_sin>(numpy, "sin") < 0) {
         return -1;
     }

--- a/quaddtype/release_tracker.md
+++ b/quaddtype/release_tracker.md
@@ -34,7 +34,7 @@
 | log           | ✅    | ✅                                                                   |
 | log2          | ✅    | ✅                                                                   |
 | log10         | ✅    | ✅                                                                   |
-| expm1         |       |                                                                      |
+| expm1         | ✅    | ✅                                                                   |
 | log1p         | ✅    | ✅                                                                   |
 | sqrt          | ✅    | ✅                                                                   |
 | square        | ✅    | ✅                                                                   |


### PR DESCRIPTION
## Copilot Summary
This pull request adds support for the `expm1` function (which computes `exp(x) - 1` with high precision) to the quad-precision and long double numerical types in the project. The implementation includes the core operation, integration with the NumPy interface, updates to documentation, and comprehensive tests to ensure correctness and precision.

**Functionality additions:**

* Added `quad_expm1` and `ld_expm1` functions to compute `expm1` for quad-precision (`Sleef_quad`) and long double types in `ops.hpp`. [[1]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R127-R132) [[2]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R317-R322)
* Registered the new `expm1` function with the NumPy ufunc interface, making it available for use in Python via the quad-precision type.

**Documentation and testing:**

* Updated the release tracker to indicate that `expm1` is now implemented and tested for both quad and long double types.
* Added a comprehensive test suite for `expm1` in `test_quaddtype.py`, covering a wide range of values including edge cases, small inputs, large inputs, and special values (inf, nan).