### PR TITLE
FEAT: `hypot` ufunc implementation

### DIFF
--- a/quaddtype/numpy_quaddtype/src/ops.hpp
+++ b/quaddtype/numpy_quaddtype/src/ops.hpp
@@ -838,6 +838,13 @@ quad_heaviside(const Sleef_quad *x1, const Sleef_quad *x2)
     }
 }
 
+static inline Sleef_quad
+quad_hypot(const Sleef_quad *x1, const Sleef_quad *x2)
+{
+    // hypot(x1, x2) = sqrt(x1^2 + x2^2)
+    return Sleef_hypotq1_u05(*x1, *x2);
+}
+
 // Binary long double operations
 typedef long double (*binary_op_longdouble_def)(const long double *, const long double *);
 // Binary long double operations with 2 outputs (for divmod, modf, frexp)
@@ -1106,6 +1113,14 @@ ld_heaviside(const long double *x1, const long double *x2)
     else {
         return 1.0L;
     }
+}
+
+static inline long double
+ld_hypot(const long double *x1, const long double *x2)
+{
+    // hypot(x1, x2) = sqrt(x1^2 + x2^2)
+    // Use the standard library hypotl function
+    return hypotl(*x1, *x2);
 }
 
 // comparison quad functions

--- a/quaddtype/numpy_quaddtype/src/umath/binary_ops.cpp
+++ b/quaddtype/numpy_quaddtype/src/umath/binary_ops.cpp
@@ -457,6 +457,9 @@ init_quad_binary_ops(PyObject *numpy)
     if (create_quad_binary_ufunc<quad_heaviside, ld_heaviside>(numpy, "heaviside") < 0) {
         return -1;
     }
+    if (create_quad_binary_ufunc<quad_hypot, ld_hypot>(numpy, "hypot") < 0) {
+        return -1;
+    }
     if (create_quad_binary_2out_ufunc<quad_divmod, ld_divmod>(numpy, "divmod") < 0) {
         return -1;
     }

--- a/quaddtype/release_tracker.md
+++ b/quaddtype/release_tracker.md
@@ -29,9 +29,6 @@
 | heaviside     | ✅    | ✅                                                                   |
 | conj          | ✅    | ✅                                                                   |
 | conjugate     | ✅    | ✅                                                                   |
-| heaviside     | ✅    | ✅                                                                   |
-| conj          |       |                                                                      |
-| conjugate     |       |                                                                      |
 | exp           | ✅    | ✅                                                                   |
 | exp2          | ✅    | ✅                                                                   |
 | log           | ✅    | ✅                                                                   |
@@ -50,7 +47,7 @@
 | arccos        | ✅    | ❌ _Need: basic tests + edge cases (NaN/inf/±1/out-of-domain)_       |
 | arctan        | ✅    | ❌ _Need: basic tests + edge cases (NaN/inf/0/asymptotes)_           |
 | arctan2       | ✅    | ❌ _Need: basic tests + edge cases (NaN/inf/0/quadrant coverage)_    |
-| hypot         |       |                                                                      |
+| hypot         | ✅    | ✅                                                                   |
 | sinh          | ✅    | ✅                                                                   |
 | cosh          | ✅    | ✅                                                                   |
 | tanh          | ✅    | ✅                                                                   |

--- a/quaddtype/tests/test_quaddtype.py
+++ b/quaddtype/tests/test_quaddtype.py
@@ -1859,3 +1859,49 @@ def test_conj_conjugate_identity(func, value):
     else:
         assert result == x
 
+
+@pytest.mark.parametrize("x1,x2,expected", [
+    # Basic Pythagorean triples
+    (3.0, 4.0, 5.0),
+    (5.0, 12.0, 13.0),
+    # Zero cases
+    (0.0, 0.0, 0.0),
+    (0.0, 5.0, 5.0),
+    (5.0, 0.0, 5.0),
+    # Negative values (hypot uses absolute values)
+    (-3.0, -4.0, 5.0),
+    (-3.0, 4.0, 5.0),
+    (3.0, -4.0, 5.0),
+    # Symmetry
+    (3.14159265358979323846, 2.71828182845904523536, None),  # Will test symmetry
+    (2.71828182845904523536, 3.14159265358979323846, None),  # Will test symmetry
+    # Infinity cases
+    (np.inf, 0.0, np.inf),
+    (0.0, np.inf, np.inf),
+    (np.inf, np.inf, np.inf),
+    (-np.inf, 0.0, np.inf),
+    (np.inf, -np.inf, np.inf),
+    # NaN cases
+    (np.nan, 3.0, np.nan),
+    (3.0, np.nan, np.nan),
+    (np.nan, np.nan, np.nan),
+])
+def test_hypot(x1, x2, expected):
+    """Test hypot ufunc with various edge cases"""
+    q1 = QuadPrecision(x1)
+    q2 = QuadPrecision(x2)
+    result = np.hypot(q1, q2)
+    
+    assert isinstance(result, QuadPrecision)
+    
+    if expected is None:
+        # Symmetry test - just check the values are equal
+        result_reverse = np.hypot(q2, q1)
+        assert result == result_reverse
+    elif np.isnan(expected):
+        assert np.isnan(float(result))
+    elif np.isinf(expected):
+        assert np.isinf(float(result))
+    else:
+        np.testing.assert_allclose(float(result), expected, rtol=1e-13)
+


### PR DESCRIPTION
## Copilot Summary
This pull request adds support for the `hypot` (Euclidean norm) operation to the quad-precision NumPy extension, including both implementation and comprehensive tests. The changes ensure that the `hypot` function is available for quad-precision and long double types, is registered as a universal function (ufunc), and is tracked in the release documentation.

### Quad-precision and long double hypot implementation

* Added the `quad_hypot` and `ld_hypot` functions to `ops.hpp`, providing quad-precision and long double implementations of the `hypot` operation using `Sleef_hypotq1_u05` and the standard library `hypotl`, respectively. [[1]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R841-R847) [[2]](diffhunk://#diff-ad4140fa03d374f246bdc4d441d868fa759788f2d27a7a29ca259b16780f0850R1118-R1125)

### Ufunc registration

* Registered the new `hypot` operation as a binary ufunc in `umath/binary_ops.cpp`, making it available to users via NumPy.

### Release tracking

* Updated `release_tracker.md` to mark `hypot` as implemented and tested, ensuring the documentation reflects the new functionality. [[1]](diffhunk://#diff-9a8d1695558967d5a5b225279cc808e3c56046d578af1a0a31b3febfbb9862f5L32-L34) [[2]](diffhunk://#diff-9a8d1695558967d5a5b225279cc808e3c56046d578af1a0a31b3febfbb9862f5L53-R50)

### Testing

* Added a comprehensive parameterized test for the `hypot` ufunc in `test_quaddtype.py`, covering basic cases, symmetry, zero, negative values, infinities, and NaNs to ensure correctness and robustness.