### PR TITLE
configure dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  labels: [dependabot]
+  commit-message:
+    prefix: "🤖"
+  groups:
+    actions:
+      patterns: ["*"]


### PR DESCRIPTION
I noticed several outdated action versions in the workflows, so I figured that dependabot could help with that.
