### PR TITLE
CI: fix inclusion path in typecheck workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/typecheck.yml
-      - quaddtype/numpy_quaddtype/*
+      - quaddtype/numpy_quaddtype/**
       - quaddtype/meson.build
       - quaddtype/pyproject.toml
   workflow_dispatch:


### PR DESCRIPTION
I noticed that it wasn't running in #221. This should fix it.