### PR TITLE
Fixing `QuadPrecision` scalar dtype exposure

### DIFF
--- a/quaddtype/numpy_quaddtype/src/scalar.c
+++ b/quaddtype/numpy_quaddtype/src/scalar.c
@@ -605,7 +605,15 @@ static PyMethodDef QuadPrecision_methods[] = {
     {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 
+static PyObject *
+QuadPrecision_get_dtype(QuadPrecisionObject *self, void *NPY_UNUSED(closure))
+{
+    QuadPrecDTypeObject *dtype = new_quaddtype_instance(self->backend);
+    return (PyObject *)dtype;
+}
+
 static PyGetSetDef QuadPrecision_getset[] = {
+    {"dtype", (getter)QuadPrecision_get_dtype, NULL, "Data type descriptor for this scalar", NULL},
     {"real", (getter)QuadPrecision_get_real, NULL, "Real part of the scalar", NULL},
     {"imag", (getter)QuadPrecision_get_imag, NULL, "Imaginary part of the scalar (always 0 for real types)", NULL},
     {NULL}  /* Sentinel */

--- a/quaddtype/tests/test_quaddtype.py
+++ b/quaddtype/tests/test_quaddtype.py
@@ -4293,3 +4293,18 @@ class Test_Is_Integer_Methods:
         quad_ratio = quad_num / quad_denom
         float_ratio = float_num / float_denom
         assert abs(quad_ratio - float_ratio) < 1e-15
+
+def test_quadprecision_scalar_dtype_expose():
+    quad_ld = QuadPrecision("1e100", backend="longdouble")
+    quad_sleef = QuadPrecision("1e100", backend="sleef")
+    assert quad_ld.dtype == QuadPrecDType(backend='longdouble')
+    assert np.dtype(quad_ld) == QuadPrecDType(backend='longdouble')
+    
+    #todo: Uncomment them when 232 is merged
+    # assert quad_ld.dtype.backend == 1
+    # assert np.dtype(quad_ld).backend == 1
+
+    assert quad_sleef.dtype == QuadPrecDType(backend='sleef')
+    assert np.dtype(quad_sleef) == QuadPrecDType(backend='sleef')
+    # assert quad_sleef.dtype.backend == 0
+    # assert np.dtype(quad_sleef).backend == 0


### PR DESCRIPTION
closes numpy/numpy-quaddtype#8 