### PR TITLE
Fix: Making `pow` compatible with cpython `pow` signature

### DIFF
--- a/quaddtype/numpy_quaddtype/src/scalar_ops.cpp
+++ b/quaddtype/numpy_quaddtype/src/scalar_ops.cpp
@@ -228,11 +228,23 @@ QuadPrecision_int(QuadPrecisionObject *self)
     }
 }
 
+template <binary_op_quad_def sleef_op, binary_op_longdouble_def longdouble_op>
+static PyObject *
+quad_ternary_power_func(PyObject *op1, PyObject *op2, PyObject *mod)
+{
+    if (mod != Py_None) {
+        PyErr_SetString(PyExc_TypeError,
+            "pow() 3rd argument not allowed unless all arguments are integers");
+        return NULL;
+    }
+    return quad_binary_func<sleef_op, longdouble_op>(op1, op2);
+}
+
 PyNumberMethods quad_as_scalar = {
         .nb_add = (binaryfunc)quad_binary_func<quad_add, ld_add>,
         .nb_subtract = (binaryfunc)quad_binary_func<quad_sub, ld_sub>,
         .nb_multiply = (binaryfunc)quad_binary_func<quad_mul, ld_mul>,
-        .nb_power = (ternaryfunc)quad_binary_func<quad_pow, ld_pow>,
+        .nb_power = (ternaryfunc)quad_ternary_power_func<quad_pow, ld_pow>,
         .nb_negative = (unaryfunc)quad_unary_func<quad_negative, ld_negative>,
         .nb_positive = (unaryfunc)quad_unary_func<quad_positive, ld_positive>,
         .nb_absolute = (unaryfunc)quad_unary_func<quad_absolute, ld_absolute>,

--- a/quaddtype/tests/test_quaddtype.py
+++ b/quaddtype/tests/test_quaddtype.py
@@ -5412,3 +5412,12 @@ def test_float_to_quad_sign_preserve(dtype, val):
         assert np.isnan(result), f"NaN failed for {dtype}"
     else:
         assert result == val, f"{val} failed for {dtype}"
+
+@pytest.mark.parametrize("val, pow", [(2, 112), (2, -112), (10, 34), (10, -34)])
+def test_quadprecision_large_exponents(val, pow):
+    mp.prec = 113
+    mp_value = mp.mpf(val) ** pow
+    value = QuadPrecision(val) ** pow
+    value_str = mp.nstr(mp.mpf(str(value)), 33)
+    expected_str = mp.nstr(mp_value, 33)
+    assert value_str == expected_str, f"QuadPrecision({val}) ** {pow} = {value_str}, expected {expected_str}"


### PR DESCRIPTION
closes numpy/numpy-quaddtype#3 